### PR TITLE
Add cluster info to workloads

### DIFF
--- a/ansible/roles/openshift_workload_deployer/tasks/get_cluster_info.yml
+++ b/ansible/roles/openshift_workload_deployer/tasks/get_cluster_info.yml
@@ -1,0 +1,88 @@
+---
+# This file gets cluster information for a single cluster
+# The calling task should set environment variables K8S_AUTH_HOST and K8S_AUTH_API_KEY
+# The calling task should set current_cluster_name variable
+
+# Module Defaults
+- name: Get Cluster Information
+  module_defaults:
+    group/k8s:
+      host: "{{ current_cluster_k8s_auth_host }}"
+      api_key: "{{ current_cluster_k8s_auth_api_key }}"
+      validate_certs: "{{ current_cluster_k8s_auth_verify_ssl | bool }}"
+  block:
+  - name: "Determine web console URL ({{ current_cluster_name }})"
+    kubernetes.core.k8s_info:
+      api_version: config.openshift.io/v1
+      kind: Console
+      name: cluster
+    register: r_console
+    retries: 30
+
+  - name: "Determine web console URL ({{ current_cluster_name }})"
+    kubernetes.core.k8s_info:
+      api_version: config.openshift.io/v1
+      kind: Console
+      name: cluster
+    register: r_console
+    retries: 30
+    delay: 5
+    until:
+    - r_console.resources | length > 0
+    - r_console.resources[0].status is defined
+    - r_console.resources[0].status.consoleURL is defined
+    - r_console.resources[0].status.consoleURL | length > 0
+
+  - name: "Determine API server URL ({{ current_cluster_name }})"
+    kubernetes.core.k8s_info:
+      api_version: config.openshift.io/v1
+      kind: Infrastructure
+      name: cluster
+    register: r_api
+    retries: 30
+    delay: 5
+    until:
+    - r_api.resources | length > 0
+    - r_api.resources[0].status is defined
+    - r_api.resources[0].status.apiServerURL is defined
+    - r_api.resources[0].status.apiServerURL | length > 0
+
+  - name: "Determine OpenShift Ingress Domain ({{ current_cluster_name }})"
+    kubernetes.core.k8s_info:
+      api_version: config.openshift.io/v1
+      kind: Ingress
+      name: cluster
+    register: r_ingress
+    retries: 30
+    delay: 5
+    until:
+    - r_ingress.resources | length > 0
+    - r_ingress.resources[0].spec.domain is defined
+    - r_ingress.resources[0].spec.domain | length > 0
+
+- name: "Set facts for OpenShift access ({{ current_cluster_name }})"
+  ansible.builtin.set_fact:
+    openshift_api_url: "{{ r_api.resources[0].status.apiServerURL | urlsplit('hostname') }}"
+    openshift_console_url: "{{ r_console.resources[0].status.consoleURL }}"
+    openshift_cluster_ingress_domain: "{{ r_ingress.resources[0].spec.domain }}"
+
+- name: "Update cluster info dictionary ({{ current_cluster_name }})"
+  ansible.builtin.set_fact:
+    _openshift_workload_deployer_cluster_info: >-
+      {{
+        _openshift_workload_deployer_cluster_info | combine({
+          current_cluster_name: {
+            'api_url': openshift_api_url,
+            'console_url': openshift_console_url,
+            'ingress_domain': openshift_cluster_ingress_domain
+          }
+        })
+      }}
+
+- name: "Debug cluster info for {{ current_cluster_name }}"
+  ansible.builtin.debug:
+    msg:
+      - "Cluster: {{ current_cluster_name }}"
+      - "API URL: {{ openshift_api_url }}"
+      - "Console URL: {{ openshift_console_url }}"
+      - "Ingress Domain: {{ openshift_cluster_ingress_domain }}"

--- a/ansible/roles/openshift_workload_deployer/tasks/main.yml
+++ b/ansible/roles/openshift_workload_deployer/tasks/main.yml
@@ -5,20 +5,45 @@
       openshift_workload_deployer_clusters: {{ openshift_workload_deployer_clusters }}
       openshift_workload_deployer_workloads: {{ openshift_workload_deployer_workloads }}
 
-- name: Build cluster lookup dictionary
+- name: Create cluster lookup dictionary for easier access
   ansible.builtin.set_fact:
-    _openshift_workload_deployer_clusters: "{{ _openshift_workload_deployer_clusters | combine(item) }}"
-  loop: "{{ openshift_workload_deployer_clusters }}"
+    _cluster_configs: "{{ _cluster_configs | default({}) | combine({item.key: item.value}) }}"
+  loop: "{{ openshift_workload_deployer_clusters | map('dict2items') | list | flatten }}"
+
+- name: Get cluster information for each cluster
+  ansible.builtin.include_tasks: get_cluster_info.yml
+  loop: "{{ openshift_workload_deployer_clusters | map('dict2items') | list }}"
+  loop_control:
+    loop_var: cluster_pair
+    label: "Getting info for cluster: {{ cluster_pair[0].key }}"
+  vars:
+    current_cluster_name: "{{ cluster_pair[0].key }}"
+    current_cluster_config: "{{ cluster_pair[0].value }}"
+    current_cluster_k8s_auth_host: "https://{{ current_cluster_config.sandbox_openshift_api_url }}:6443"
+    current_cluster_k8s_auth_api_key: "{{ current_cluster_config.sandbox_openshift_api_token }}"
+    current_cluster_k8s_auth_verify_ssl: false
+
+- name: Debug final cluster info dictionary
+  ansible.builtin.debug:
+    msg: "{{ _openshift_workload_deployer_cluster_info }}"
+
+# - name: Don't actually do anything yet
+#   ansible.builtin.fail:
+#     msg: "Don't actually do anything yet"
 
 - name: Deploy workloads to clusters
   ansible.builtin.include_role:
     name: "{{ workload_item.0.name }}"
     apply:
       environment:
-        K8S_AUTH_HOST: "https://{{ _openshift_workload_deployer_clusters[workload_item.1].api_url }}:6443"
-        K8S_AUTH_API_KEY: "{{ _openshift_workload_deployer_clusters[workload_item.1].api_token }}"
+        K8S_AUTH_HOST: "https://{{ _cluster_configs[workload_item.1].sandbox_openshift_api_url }}:6443"
+        K8S_AUTH_API_KEY: "{{ _cluster_configs[workload_item.1].sandbox_openshift_api_token }}"
         K8S_AUTH_VERIFY_SSL: false
   loop: "{{ openshift_workload_deployer_workloads | subelements('clusters') }}"
   loop_control:
     loop_var: workload_item
     label: "Role: {{ workload_item.0.name }} on Cluster: {{ workload_item.1 }}"
+  vars:
+    openshift_api_url: "{{ _openshift_workload_deployer_cluster_info[workload_item.1].api_url }}"
+    openshift_console_url: "{{ _openshift_workload_deployer_cluster_info[workload_item.1].console_url }}"
+    openshift_cluster_ingress_domain: "{{ _openshift_workload_deployer_cluster_info[workload_item.1].ingress_domain }}"

--- a/ansible/roles/openshift_workload_deployer/tasks/main.yml
+++ b/ansible/roles/openshift_workload_deployer/tasks/main.yml
@@ -4,6 +4,7 @@
     msg: |
       openshift_workload_deployer_clusters: {{ openshift_workload_deployer_clusters }}
       openshift_workload_deployer_workloads: {{ openshift_workload_deployer_workloads }}
+    verbosity: 2
 
 - name: Create cluster lookup dictionary for easier access
   ansible.builtin.set_fact:
@@ -26,10 +27,6 @@
 - name: Debug final cluster info dictionary
   ansible.builtin.debug:
     msg: "{{ _openshift_workload_deployer_cluster_info }}"
-
-# - name: Don't actually do anything yet
-#   ansible.builtin.fail:
-#     msg: "Don't actually do anything yet"
 
 - name: Deploy workloads to clusters
   ansible.builtin.include_role:

--- a/ansible/roles/openshift_workload_deployer/vars/main.yml
+++ b/ansible/roles/openshift_workload_deployer/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-_openshift_workload_deployer_clusters: {}
+_openshift_workload_deployer_cluster_info: {}


### PR DESCRIPTION
##### SUMMARY

Workloads now get info about the cluster (api/ingress/apps domain) pre-populated like with openshift-cluster.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
openshift_workloads
openshift_workload_deployer