### PR TITLE
Fix typo in workloads example, fix workload deployer

### DIFF
--- a/ansible/roles/openshift_workload_deployer/tasks/get_cluster_info.yml
+++ b/ansible/roles/openshift_workload_deployer/tasks/get_cluster_info.yml
@@ -18,14 +18,6 @@
       name: cluster
     register: r_console
     retries: 30
-
-  - name: "Determine web console URL ({{ current_cluster_name }})"
-    kubernetes.core.k8s_info:
-      api_version: config.openshift.io/v1
-      kind: Console
-      name: cluster
-    register: r_console
-    retries: 30
     delay: 5
     until:
     - r_console.resources | length > 0
@@ -82,7 +74,7 @@
 - name: "Debug cluster info for {{ current_cluster_name }}"
   ansible.builtin.debug:
     msg:
-      - "Cluster: {{ current_cluster_name }}"
-      - "API URL: {{ openshift_api_url }}"
-      - "Console URL: {{ openshift_console_url }}"
-      - "Ingress Domain: {{ openshift_cluster_ingress_domain }}"
+      - "current_cluster_name: {{ current_cluster_name }}"
+      - "openshift_api_url: {{ openshift_api_url }}"
+      - "openshift_console_url: {{ openshift_console_url }}"
+      - "openshift_cluster_ingress_domain: {{ openshift_cluster_ingress_domain }}"

--- a/ansible/roles/openshift_workload_deployer/tasks/main.yml
+++ b/ansible/roles/openshift_workload_deployer/tasks/main.yml
@@ -4,12 +4,20 @@
     msg: |
       openshift_workload_deployer_clusters: {{ openshift_workload_deployer_clusters }}
       openshift_workload_deployer_workloads: {{ openshift_workload_deployer_workloads }}
-    verbosity: 2
+    # verbosity: 2
 
 - name: Create cluster lookup dictionary for easier access
   ansible.builtin.set_fact:
     _cluster_configs: "{{ _cluster_configs | default({}) | combine({item.key: item.value}) }}"
   loop: "{{ openshift_workload_deployer_clusters | map('dict2items') | list | flatten }}"
+
+- name: Debug dictionary
+  ansible.builtin.debug:
+    var: _cluster_configs
+
+- name: Debug list
+  ansible.builtin.debug:
+    var: openshift_workload_deployer_clusters | map('dict2items') | list
 
 - name: Get cluster information for each cluster
   ansible.builtin.include_tasks: get_cluster_info.yml
@@ -20,8 +28,8 @@
   vars:
     current_cluster_name: "{{ cluster_pair[0].key }}"
     current_cluster_config: "{{ cluster_pair[0].value }}"
-    current_cluster_k8s_auth_host: "https://{{ current_cluster_config.sandbox_openshift_api_url }}:6443"
-    current_cluster_k8s_auth_api_key: "{{ current_cluster_config.sandbox_openshift_api_token }}"
+    current_cluster_k8s_auth_host: "https://{{ current_cluster_config.api_url }}:6443"
+    current_cluster_k8s_auth_api_key: "{{ current_cluster_config.api_token }}"
     current_cluster_k8s_auth_verify_ssl: false
 
 - name: Debug final cluster info dictionary
@@ -33,8 +41,8 @@
     name: "{{ workload_item.0.name }}"
     apply:
       environment:
-        K8S_AUTH_HOST: "https://{{ _cluster_configs[workload_item.1].sandbox_openshift_api_url }}:6443"
-        K8S_AUTH_API_KEY: "{{ _cluster_configs[workload_item.1].sandbox_openshift_api_token }}"
+        K8S_AUTH_HOST: "https://{{ _cluster_configs[workload_item.1].api_url }}:6443"
+        K8S_AUTH_API_KEY: "{{ _cluster_configs[workload_item.1].api_token }}"
         K8S_AUTH_VERIFY_SSL: false
   loop: "{{ openshift_workload_deployer_workloads | subelements('clusters') }}"
   loop_control:

--- a/bin/templates/openshift-workloads.yml
+++ b/bin/templates/openshift-workloads.yml
@@ -25,7 +25,7 @@ requirements_content:
 clusters:
 - default:
     api_url: "{{ cluster1.sandbox_openshift_api_url }}"
-    api_token: "{{ cluster1.sandbox_openshfit_api_token }}"
+    api_token: "{{ cluster1.sandbox_openshift_api_token }}"
 
 # ===================================================================
 # List of workloads to apply to clusters with cluster selector


### PR DESCRIPTION
##### SUMMARY

Workloads example had a typo
Workload deployer didn't pass api url and token properly to workloads.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
openshift-workloads.yml
openshift_workload_deployer