### PR TITLE
Make sure a catalogsource name is set

### DIFF
--- a/ansible/roles/install_operator/templates/catalogsource.yaml.j2
+++ b/ansible/roles/install_operator/templates/catalogsource.yaml.j2
@@ -2,7 +2,11 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:
+{% if install_operator_catalogsource_name | default("") | length > 0 %}
   name: {{ install_operator_catalogsource_name }}
+{% else %}
+  name: {{ install_operator_name }}-catalogsource
+{% endif %}
   namespace: {{ install_operator_catalogsource_namespace }}
 spec:
   sourceType: grpc


### PR DESCRIPTION
##### SUMMARY

Creating the catalogsource failed if no Catalogsource name was passed. Fixed by setting a default name if no name is passed.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
install_operator