### PR TITLE
Ensure that startingCSVs have autoapprove set to false

### DIFF
--- a/ansible/roles/install_operator/defaults/main.yml
+++ b/ansible/roles/install_operator/defaults/main.yml
@@ -27,10 +27,6 @@ install_operator_catalog: redhat-operators
 install_operator_channel: ""
 # install_operator_channel: "4.7"
 
-# Set automatic InstallPlan approval. If set to false it is also suggested
-# to set the starting_csv to pin a specific version
-install_operator_automatic_install_plan_approval: true
-
 # CSV Name. Some operators (pipelines, cough, cough) use different CSV names from
 # the operator or package manifest names.
 install_operator_csv_nameprefix: "{{ install_operator_name }}"
@@ -41,7 +37,15 @@ install_operator_csv_nameprefix: "{{ install_operator_name }}"
 # Highly recommended to be set when using a catalog snapshot but can be
 # empty to get the latest available in the channel at the time when
 # the catalog snapshot got created.
+# Automatic install plan approval must be false when using a starting CSV.
 install_operator_starting_csv: ""
+
+# Set automatic InstallPlan approval.
+# This must be false when using a starting CSV to prevent multiple updates
+# upon installation of the operator.
+# It _can_ be set to false when not using a starting CSV to prevent further updates
+# to the operator when new versions are released on longer running clusters.
+install_operator_automatic_install_plan_approval: true
 
 # List of Namespaces for the Operator to manage.
 # Empty list to manage the entire cluster
@@ -52,7 +56,15 @@ install_operator_manage_namespaces: []
 # Extra configuration to add to the subscription
 # Whatever yaml definition is specified here will make it into the subscription
 # .spec.config section.
-install_operator_subscription_config: ""
+install_operator_subscription_config: {}
+
+# If your operator doesnt need to create a OperatorGroup, because it already exists, set to true
+install_operator_skip_operatorgroup: false
+
+# If issues with the operator, when creating the CSV, the playbook will continue executing.
+# Accepted values: true , false
+# Default value: false
+install_operator_install_csv_ignore_error: false
 
 # -----------------------------------------------------
 # Custom Catalog Source, e.g. Operator Catalog Snapshot
@@ -84,11 +96,3 @@ install_operator_catalogsource_image_tag: "v4.18_2025_06_02"
 # install_operator_catalogsource_secrets:
 # - my_pull_secret_name
 install_operator_catalogsource_pullsecrets: []
-
-# If issues with the operator, when creating the CSV, the playbook will continue executing.
-# Accepted values: true , false
-# Default value: false
-install_operator_install_csv_ignore_error: false
-
-# If your operator doesnt need to create a OperatorGroup, because it already exists, set to true
-install_operator_skip_operatorgroup: false

--- a/ansible/roles/install_operator/tasks/install.yml
+++ b/ansible/roles/install_operator/tasks/install.yml
@@ -5,6 +5,13 @@
     - install_operator_name | default("") | length > 0
     fail_msg: install_operator_name must be set.
 
+- name: Check that starting CSV also has autoapprove set to false
+  when: install_operator_starting_csv | default("") | length > 0
+  ansible.builtin.assert:
+    that:
+    - not install_operator_automatic_install_plan_approval | default(true)
+    fail_msg: Install plan automatic approval must be set to false when using a starting CSV.
+
 - name: "Set up for Namespace other than 'openshift-operators' ({{ install_operator_name }})"
   when: install_operator_namespace != "openshift-operators"
   block:
@@ -142,44 +149,6 @@
     register: r_csv
     retries: 30
     delay: 10
-    until:
-    - r_csv.resources[0].status.phase is defined
-    - r_csv.resources[0].status.phase | length > 0
-    - r_csv.resources[0].status.phase == "Succeeded"
-    ignore_errors: "{{ install_operator_install_csv_ignore_error }}"
-
-  rescue:
-  - name: Pause for 5 minute waiting for CSV replacements
-    ansible.builtin.pause:
-      minutes: 5
-
-  - name: "Get Installed CSV ({{ install_operator_name }})"
-    kubernetes.core.k8s_info:
-      api_version: operators.coreos.com/v1alpha1
-      kind: Subscription
-      name: "{{ install_operator_name }}"
-      namespace: "{{ install_operator_namespace }}"
-    register: r_subscription
-    retries: 30
-    delay: 10
-    until:
-    - r_subscription.resources[0].status.currentCSV is defined
-    - r_subscription.resources[0].status.currentCSV | length > 0
-
-  - name: "Print CSV version to be installed ({{ install_operator_name }})"
-    when: install_operator_starting_csv is defined
-    ansible.builtin.debug:
-      msg: "Starting CSV: {{ install_operator_starting_csv }}"
-
-  - name: "Wait until CSV is installed ({{ install_operator_name }})"
-    kubernetes.core.k8s_info:
-      api_version: operators.coreos.com/v1alpha1
-      kind: ClusterServiceVersion
-      name: "{{ r_subscription.resources[0].status.currentCSV }}"
-      namespace: "{{ install_operator_namespace }}"
-    register: r_csv
-    retries: 10
-    delay: 30
     until:
     - r_csv.resources[0].status.phase is defined
     - r_csv.resources[0].status.phase | length > 0


### PR DESCRIPTION
##### SUMMARY

When using install_operator it is possible to specify a startingCSV. In that case the automatic install plan approval must be set to false.

Adding assertion. Removing unnecessary code that was caused by these settings being set wrongly.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
install_operator