### PR TITLE
Add install_operator_catalogsource_priority setting

### DIFF
--- a/ansible/roles/install_operator/defaults/main.yml
+++ b/ansible/roles/install_operator/defaults/main.yml
@@ -83,6 +83,13 @@ install_operator_catalogsource_name: "{{ install_operator_name }}-catalogsource"
 # Namespace to install the custom catalog source into:
 install_operator_catalogsource_namespace: "{{ install_operator_namespace }}"
 
+# Priority of the catalog source. Default is 0. Defines order in the OperatorHub and when looking
+# up dependent operators without a catalog source.
+# Important: Dependent operators will be installed from the highest priority catalog source.
+#            So to force OLM to install a dependent operator from the same catalog source set
+#            the priority to a value > 0.
+install_operator_catalogsource_priority: -5
+
 # Catalog source container image
 install_operator_catalogsource_image: quay.io/gpte-devops-automation/olm_snapshot_redhat_catalog
 

--- a/ansible/roles/install_operator/templates/catalogsource.yaml.j2
+++ b/ansible/roles/install_operator/templates/catalogsource.yaml.j2
@@ -13,6 +13,7 @@ spec:
   image: {{ install_operator_catalogsource_image }}:{{ install_operator_catalogsource_image_tag }}
   displayName: {{ install_operator_catalogsource_name }}
   publisher: Red Hat AgnosticD
+  priority: {{ install_operator_catalogsource_priority | int }}
 {% if install_operator_catalogsource_pullsecrets | length > 0 %}
   secrets: {{ install_operator_catalogsource_pullsecrets | to_json }}
 {% endif %}


### PR DESCRIPTION
##### SUMMARY

# Priority of the catalog source. Default is 0. Defines order in the OperatorHub and when looking
# up dependent operators without a catalog source.
# Important: Dependent operators will be installed from the highest priority catalog source.
#            So to force OLM to install a dependent operator from the same catalog source set
#            the priority to a value > 0.
install_operator_catalogsource_priority: -5


##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
install_operator