### PR TITLE
Revert updating EE version to fall back to Ansible 2.18.

### DIFF
--- a/ansible-navigator.yml
+++ b/ansible-navigator.yml
@@ -2,7 +2,7 @@
 ansible-navigator:
   execution-environment:
     container-engine: podman
-    image: quay.io/agnosticd/ee-multicloud:chained-2025-08-12
+    image: quay.io/agnosticd/ee-multicloud:chained-2025-06-30
     pull:
       policy: missing
   format: json


### PR DESCRIPTION
##### SUMMARY

Ansible 2.19 breaks the agnosticd_user_info module. Reverting the EE back to a version with Ansible 2.18

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-navigator.yml