### PR TITLE
Run cluster recovery options on localhost instead of bastion

### DIFF
--- a/ansible/configs/openshift-cluster/lifecycle_hook_post_start.yml
+++ b/ansible/configs/openshift-cluster/lifecycle_hook_post_start.yml
@@ -48,7 +48,7 @@
         -F {{ hostvars.localhost.output_dir }}/{{ config }}_{{ guid }}_ssh_conf
 
 - name: Run recover cluster actions
-  hosts: bastions
+  hosts: localhost
   run_once: true
   become: false
   gather_facts: false


### PR DESCRIPTION
##### SUMMARY

Cluster recovery (CSR approval) ran on bastion where no valid kubeconfig was found. Running on localhost (in the EE) instead.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
openshift-cluster