### PR TITLE
Add async_dir to ansible.cfg

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,6 +1,7 @@
 [defaults]
 nocows                  = 1
 roles_path              = ansible/dynamic_roles:ansible/roles
+async_dir               = /home/runner
 forks                   = 50
 become                  = false
 gathering               = smart


### PR DESCRIPTION
##### SUMMARY

@newgoliath found that the `async_dir` setting was necessary for proper async logs.
Adding to `ansible.cfg`

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible.cfg