### PR TITLE
Revert async dir change because it broke OCP install

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,7 +1,6 @@
 [defaults]
 nocows                  = 1
 roles_path              = ansible/dynamic_roles:ansible/roles
-async_dir               = /home/runner
 forks                   = 50
 become                  = false
 gathering               = smart


### PR DESCRIPTION
##### SUMMARY

Having async_dir set in ansible.cfg breaks openshift installation. Reverting that change. @newgoliath FYI

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible.cfg