### PR TITLE
Task failed with an empty list of workloads. Adding default.

### DIFF
--- a/ansible/configs/namespace/software.yml
+++ b/ansible/configs/namespace/software.yml
@@ -13,7 +13,7 @@
   gather_facts: false
   become: false
   tasks:
-  - name: Apply namespaced workload "{{ workload_loop_var }}"
+  - name: Apply namespaced workload "{{ workload_loop_var | default('None') }}"
     when: workloads | default([]) | length > 0
     ansible.builtin.include_role:
       name: "{{ workload_loop_var }}"


### PR DESCRIPTION
##### SUMMARY

The loop to install workloads failed when an empty list was passed. Fixed by adding a default.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
namespace