### PR TITLE
[openshift-cnv provider] Set sandbox information on the user_info

### DIFF
--- a/ansible/cloud_providers/openshift_cnv/infrastructure_deployment.yml
+++ b/ansible/cloud_providers/openshift_cnv/infrastructure_deployment.yml
@@ -9,6 +9,18 @@
       host: "{{ sandbox_openshift_api_url }}"
       validate_certs: false
   tasks:
+    - name: Provide sandbox provision data
+      when:
+        - openshift_cnv_set_sandbox_provision_data | default(false) | bool
+      agnosticd_user_info:
+        data:
+          sandbox_openshift_namespace: "{{ sandbox_openshift_namespace }}"
+          sandbox_openshift_cluster: "{{ sandbox_openshift_cluster }}"
+          sandbox_openshift_api_url: "{{ sandbox_openshift_api_url }}"
+          sandbox_openshift_apps_domain: "{{ sandbox_openshift_apps_domain }}"
+          sandbox_openshift_console_url: "{{ sandbox_openshift_console_url }}"
+          sandbox_openshift_api_key: "{{ sandbox_openshift_api_key}}"
+
   - name: Create ssh provision key
     when:
     - instances | default([]) | length > 0

--- a/ansible/cloud_providers/openshift_cnv/infrastructure_deployment.yml
+++ b/ansible/cloud_providers/openshift_cnv/infrastructure_deployment.yml
@@ -12,7 +12,7 @@
   - name: Provide sandbox provision data
     when:
       - openshift_cnv_set_sandbox_provision_data | default(false) | bool
-    agnosticd.core.agnosticd_user_data:
+    agnosticd.core.agnosticd_user_info:
       data:
         sandbox_openshift_namespace: "{{ sandbox_openshift_namespace }}"
         sandbox_openshift_cluster: "{{ sandbox_openshift_cluster }}"

--- a/ansible/cloud_providers/openshift_cnv/infrastructure_deployment.yml
+++ b/ansible/cloud_providers/openshift_cnv/infrastructure_deployment.yml
@@ -12,7 +12,7 @@
   - name: Provide sandbox provision data
     when:
       - openshift_cnv_set_sandbox_provision_data | default(false) | bool
-    agnosticd_user_info:
+    agnosticd.core.agnosticd_user_data:
       data:
         sandbox_openshift_namespace: "{{ sandbox_openshift_namespace }}"
         sandbox_openshift_cluster: "{{ sandbox_openshift_cluster }}"

--- a/ansible/cloud_providers/openshift_cnv/infrastructure_deployment.yml
+++ b/ansible/cloud_providers/openshift_cnv/infrastructure_deployment.yml
@@ -9,17 +9,17 @@
       host: "{{ sandbox_openshift_api_url }}"
       validate_certs: false
   tasks:
-    - name: Provide sandbox provision data
-      when:
-        - openshift_cnv_set_sandbox_provision_data | default(false) | bool
-      agnosticd_user_info:
-        data:
-          sandbox_openshift_namespace: "{{ sandbox_openshift_namespace }}"
-          sandbox_openshift_cluster: "{{ sandbox_openshift_cluster }}"
-          sandbox_openshift_api_url: "{{ sandbox_openshift_api_url }}"
-          sandbox_openshift_apps_domain: "{{ sandbox_openshift_apps_domain }}"
-          sandbox_openshift_console_url: "{{ sandbox_openshift_console_url }}"
-          sandbox_openshift_api_key: "{{ sandbox_openshift_api_key}}"
+  - name: Provide sandbox provision data
+    when:
+      - openshift_cnv_set_sandbox_provision_data | default(false) | bool
+    agnosticd_user_info:
+      data:
+        sandbox_openshift_namespace: "{{ sandbox_openshift_namespace }}"
+        sandbox_openshift_cluster: "{{ sandbox_openshift_cluster }}"
+        sandbox_openshift_api_url: "{{ sandbox_openshift_api_url }}"
+        sandbox_openshift_apps_domain: "{{ sandbox_openshift_apps_domain }}"
+        sandbox_openshift_console_url: "{{ sandbox_openshift_console_url }}"
+        sandbox_openshift_api_key: "{{ sandbox_openshift_api_key}}"
 
   - name: Create ssh provision key
     when:


### PR DESCRIPTION
##### SUMMARY

If variable **openshift_cnv_set_sandbox_provision_data** is set to true, then is set the sandbox_ variables from sandbox-api in the user data to be used by a binder

##### ISSUE TYPE

- Feature Pull Request


##### COMPONENT NAME
openshift_cnv cloud provider
