### PR TITLE
Add bastion support to openshift-workloads

### DIFF
--- a/ansible/configs/openshift-workloads/post_infra.yml
+++ b/ansible/configs/openshift-workloads/post_infra.yml
@@ -8,3 +8,10 @@
   - name: Print stage message
     ansible.builtin.debug:
       msg: "Step 002 Post-Infrastructure"
+
+  - name: Add bastion host
+    when:
+    - bastion_ansible_host is defined
+    - bastion_ansible_user is defined
+    ansible.builtin.include_role:
+      name: infra_add_bastion

--- a/ansible/configs/openshift-workloads/software.yml
+++ b/ansible/configs/openshift-workloads/software.yml
@@ -13,7 +13,7 @@
   - name: Check if workloads is a simple list (no 'clusters' key)
     ansible.builtin.set_fact:
       _workloads_simple_format: >-
-        {{ (workloads | length > 0) and (workloads[0].clusters is not defined) }}
+        {{ (workloads | length > 0) and (not workloads[0] is mapping) }}
 
   - name: Convert simple format to complex format
     when: _workloads_simple_format | bool

--- a/ansible/roles/infra_add_bastion/defaults/main.yml
+++ b/ansible/roles/infra_add_bastion/defaults/main.yml
@@ -1,0 +1,12 @@
+---
+# Required variables for this role.
+# In the future it may support using an SSH private key rather than password.
+
+#bastion_ansible_host: ...
+#bastion_ansible_user: ...
+#bastion_ansible_ssh_pass: ...
+
+# Optional values used in add_host
+bastion_inventory_hostname: bastion
+ansible_ssh_pipelining: true
+#bastion_ansible_port:

--- a/ansible/roles/infra_add_bastion/tasks/main.yml
+++ b/ansible/roles/infra_add_bastion/tasks/main.yml
@@ -1,0 +1,17 @@
+---
+- name: Check required variables
+  ansible.builtin.assert:
+    that:
+    - bastion_ansible_host is defined
+    - bastion_ansible_user is defined
+    - bastion_ansible_ssh_pass is defined
+
+- name: Add bastion host
+  ansible.builtin.add_host:
+    name: "{{ bastion_inventory_hostname }}"
+    group: bastions
+    ansible_host: "{{ bastion_ansible_host }}"
+    ansible_port: "{{ bastion_ansible_port | default(omit) }}"
+    ansible_ssh_pass: "{{ bastion_ansible_ssh_pass }}"
+    ansible_ssh_pipelining: "{{ ansible_ssh_pipelining }}"
+    ansible_user: "{{ bastion_ansible_user }}"

--- a/ansible/roles/openshift_workload_deployer/tasks/main.yml
+++ b/ansible/roles/openshift_workload_deployer/tasks/main.yml
@@ -37,18 +37,8 @@
     msg: "{{ _openshift_workload_deployer_cluster_info }}"
 
 - name: Deploy workloads to clusters
-  ansible.builtin.include_role:
-    name: "{{ workload_item.0.name }}"
-    apply:
-      environment:
-        K8S_AUTH_HOST: "{{ _cluster_configs[workload_item.1].api_url }}"
-        K8S_AUTH_API_KEY: "{{ _cluster_configs[workload_item.1].api_token }}"
-        K8S_AUTH_VERIFY_SSL: false
-  loop: "{{ openshift_workload_deployer_workloads | subelements('clusters') }}"
+  ansible.builtin.include_tasks: run_workload_on_clusters.yml
+  loop: "{{ openshift_workload_deployer_workloads }}"
   loop_control:
     loop_var: workload_item
-    label: "Role: {{ workload_item.0.name }} on Cluster: {{ workload_item.1 }}"
-  vars:
-    openshift_api_url: "{{ _openshift_workload_deployer_cluster_info[workload_item.1].api_url }}"
-    openshift_console_url: "{{ _openshift_workload_deployer_cluster_info[workload_item.1].console_url }}"
-    openshift_cluster_ingress_domain: "{{ _openshift_workload_deployer_cluster_info[workload_item.1].ingress_domain }}"
+    label: "{{ workload_item.name }}"

--- a/ansible/roles/openshift_workload_deployer/tasks/run_workload_on_clusters.yml
+++ b/ansible/roles/openshift_workload_deployer/tasks/run_workload_on_clusters.yml
@@ -1,0 +1,16 @@
+---
+- name: Deploy workload {{ workload_item.name }} to clusters
+  ansible.builtin.include_role:
+    name: "{{ workload_item.name }}"
+    apply:
+      environment:
+        K8S_AUTH_HOST: "{{ _cluster_configs[_cluster_name].api_url }}"
+        K8S_AUTH_API_KEY: "{{ _cluster_configs[_cluster_name].api_token }}"
+        K8S_AUTH_VERIFY_SSL: false
+  loop: "{{ workload_item.clusters | default(['default']) }}"
+  loop_control:
+    loop_var: _cluster_name
+  vars:
+    openshift_api_url: "{{ _openshift_workload_deployer_cluster_info[_cluster_name].api_url }}"
+    openshift_console_url: "{{ _openshift_workload_deployer_cluster_info[_cluster_name].console_url }}"
+    openshift_cluster_ingress_domain: "{{ _openshift_workload_deployer_cluster_info[_cluster_name].ingress_domain }}"


### PR DESCRIPTION
##### SUMMARY

- Add support for using `delegate_to` in openshift workloads.
- Fix to allow workloads to be passed as a list of dicts without including "clusters" key and default clusters to default.

##### ISSUE TYPE

- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME

openshift-workloads config
openshift_workload_deployer role