### PR TITLE
Add bcrypt library to EE

### DIFF
--- a/tools/execution_environments/ee-multicloud-public/requirements.txt
+++ b/tools/execution_environments/ee-multicloud-public/requirements.txt
@@ -11,7 +11,7 @@ jsonpatch
 kubernetes>=12.0.0
 ncclient
 packet-python>=1.43.1
-passlib
+passlib[bcrypt]
 paramiko
 pexpect>=4.5
 petname


### PR DESCRIPTION
##### SUMMARY

For some reason htpasswd generation started failing with a missing bcrypt library. Adding to the requirements for the EE.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ee public multi-cloud