### PR TITLE
Fix bin/agd script and docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ set-env.sh
 user-data.yaml
 user-info.yaml
 venv
+.python-version

--- a/bin/agd
+++ b/bin/agd
@@ -102,6 +102,7 @@ agd_setup() {
           if [ "$dir" == "$SECRETS_DIR" ]; then
               cp bin/templates/secrets.yml "$dir" 2>&1 >/dev/null
               cp bin/templates/secrets-sandboxXXX.yml "$dir" 2>&1 >/dev/null
+              cp bin/templates/secrets-cnvdev.yml "$dir" 2>&1 >/dev/null
               cp bin/templates/secrets-cluster.yml "$dir" 2>&1 >/dev/null
               echo "  Copied secrets template files to $dir"
           elif [ "$dir" == "$VARS_DIR" ]; then
@@ -239,8 +240,8 @@ run_ansible_navigator() {
 #
 # -------------------------------------------------------------------
 
-# Check if we are inside the agnosticd-v2 directory
-if [ "$(basename "$PWD")" != "agnosticd-v2" ]; then
+# Check if we are inside the agnosticd-v2 directory (resolve symlinks)
+if [ "$(basename $(pwd -P))" != "agnosticd-v2" ]; then
     echo "  ERROR: This script must be run from within the agnosticd-v2 directory."
     exit 1
 fi

--- a/docs/setup.adoc
+++ b/docs/setup.adoc
@@ -313,7 +313,7 @@ Deploy a new environment using the `provision` command:
 
 [source,sh]
 ----
-./bin/agd provision --guid myocp --config openshift-cluster --account sandbox1234
+./bin/agd provision --guid myocp --config openshift-cluster-aws --account sandbox1234
 ----
 
 *Short form*:
@@ -328,7 +328,7 @@ Remove a deployed environment:
 
 [source,sh]
 ----
-./bin/agd destroy --guid myocp --config openshift-cluster --account sandbox1234
+./bin/agd destroy --guid myocp --config openshift-cluster-aws --account sandbox1234
 ----
 
 === Stopping an Environment
@@ -337,7 +337,7 @@ Stop a running environment:
 
 [source,sh]
 ----
-./bin/agd stop --guid myocp --config openshift-cluster --account sandbox1234
+./bin/agd stop --guid myocp --config openshift-cluster-aws --account sandbox1234
 ----
 
 === Starting an Environment
@@ -346,7 +346,7 @@ Start a stopped environment:
 
 [source,sh]
 ----
-./bin/agd start --guid myocp --config openshift-cluster --account sandbox1234
+./bin/agd start --guid myocp --config openshift-cluster-aws --account sandbox1234
 ----
 
 === Checking Environment Status
@@ -355,5 +355,5 @@ Get the current status of an environment:
 
 [source,sh]
 ----
-./bin/agd status --guid myocp --config openshift-cluster --account sandbox1234
+./bin/agd status --guid myocp --config openshift-cluster-aws --account sandbox1234
 ----


### PR DESCRIPTION
The script bin/agd setup did not work when running from a symlink location. I work with agd2 from a symlink path, so the script should evaluate the real path when checking the which directory is running from.

Plus some other minor fixes.