### PR TITLE
[plugins/filter] Allow source-pinned collections to override EE preinstalls

### DIFF
--- a/ansible/collections/ansible_collections/agnosticd/core/plugins/filter/core.py
+++ b/ansible/collections/ansible_collections/agnosticd/core/plugins/filter/core.py
@@ -316,12 +316,18 @@ def agnosticd_filter_out_installed_collections(requirements, installed_collectio
             # collection is not installed, keep it
             keep_collections.append(collection)
         else:
+            installed_version = installed.get(collection['name'])
+            # Keep collections that explicitly specify a source so they can
+            # override the preinstalled EE collection.
+            if collection.get('source'):
+                keep_collections.append(collection)
+                continue
             display.warning(
                 "skipping installation of %s==%s ; %s==%s already installed in EE"
                 %(collection['name'],
-                  collection['version'],
+                  collection.get('version', 'unspecified'),
                   collection['name'],
-                  installed[collection['name']])
+                  installed_version)
             )
 
 

--- a/ansible/collections/ansible_collections/agnosticd/core/plugins/tests/test_core.py
+++ b/ansible/collections/ansible_collections/agnosticd/core/plugins/tests/test_core.py
@@ -391,6 +391,11 @@ def test_agnosticd_filter_out_installed_collections():
                     {
                         "name": "openstack.cloud",
                         "version": "1.7.2"
+                    },
+                    {
+                        "name": "agnosticd.cloud_provider_openshift_cnv",
+                        "version": "1.0.0",
+                        "source": "https://github.com/agnosticd/cloud_provider_openshift_cnv"
                     }
                 ]
             },
@@ -421,6 +426,9 @@ def test_agnosticd_filter_out_installed_collections():
                     },
                     "openstack.cloud": {
                         "version": "2.0.0"
+                    },
+                    "agnosticd.cloud_provider_openshift_cnv": {
+                        "version": "0.9.0"
                     }
                 }
             }
@@ -435,6 +443,11 @@ def test_agnosticd_filter_out_installed_collections():
                     {
                         "name": "google.cloud",
                         "version": "1.0.2"
+                    },
+                    {
+                        "name": "agnosticd.cloud_provider_openshift_cnv",
+                        "version": "1.0.0",
+                        "source": "https://github.com/agnosticd/cloud_provider_openshift_cnv"
                     },
                 ]
             },


### PR DESCRIPTION
##### SUMMARY
- Keep collections that specify a `source` even when an EE already has a version installed.
- Update the filter tests to cover source-pinned overrides.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- core/plugins/filter
