### PR TITLE
Fix CI: enable fork PR builds with Galaxy secrets

### DIFF
--- a/.github/workflows/build-ee-dispatch.yml
+++ b/.github/workflows/build-ee-dispatch.yml
@@ -21,6 +21,8 @@ jobs:
     secrets:
       registry_username: ${{ secrets.QUAY_EE_MULTICLOUD_USER }}
       registry_password: ${{ secrets.QUAY_EE_MULTICLOUD_TOKEN }}
+      aap_certified_token: ${{ secrets.AAP_CERTIFIED_TOKEN }}
+      aap_validated_token: ${{ secrets.AAP_VALIDATED_TOKEN }}
     with:
       tag: ${{ inputs.tag }}
       labels: ${{ inputs.labels }}

--- a/.github/workflows/build-ee-pr.yml
+++ b/.github/workflows/build-ee-pr.yml
@@ -1,8 +1,13 @@
 ---
 name: build-ee-pr
 
+# Use pull_request_target so that secrets are available for fork PRs.
+# The workflow YAML always comes from the base branch (safe), and the
+# 'ee-build' environment requires maintainer approval before running,
+# giving reviewers a chance to inspect the PR diff for any malicious
+# changes (e.g. Containerfile echoing secrets).
 on:
-  pull_request:
+  pull_request_target:
     paths:
     - tools/execution_environments/ee-multicloud-public/**
 
@@ -19,11 +24,13 @@ jobs:
       aap_certified_token: ${{ secrets.AAP_CERTIFIED_TOKEN }}
       aap_validated_token: ${{ secrets.AAP_VALIDATED_TOKEN }}
     with:
+      ref: ${{ github.event.pull_request.head.sha }}
+      environment: ee-build
       tag: chained-temporary-pr-${{ github.event.number }}
       labels: |-
         quay.expires-after=7d
         org.opencontainers.image.source=${{ github.event.repository.html_url }}
-        org.opencontainers.image.revision=${{ github.sha }}
+        org.opencontainers.image.revision=${{ github.event.pull_request.head.sha }}
 
   get-stats-and-comment:
     name: Get stats and diff for the new image

--- a/.github/workflows/build-ee.yml
+++ b/.github/workflows/build-ee.yml
@@ -13,6 +13,16 @@ on:
         default: ''
         required: false
         type: string
+      ref:
+        description: 'Git ref to checkout (default: triggering ref)'
+        default: ''
+        required: false
+        type: string
+      environment:
+        description: 'GitHub Environment for deployment protection rules'
+        default: ''
+        required: false
+        type: string
 
     secrets:
       registry_username:
@@ -31,10 +41,13 @@ on:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    environment: ${{ inputs.environment || null }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref || github.sha }}
 
       - uses: actions/setup-python@v4
 


### PR DESCRIPTION
## Summary

Fix EE build CI so fork PRs can build complete images with certified collections.

## Problem

Fork PRs fail 100% of EE builds because GitHub does not expose repo secrets to `pull_request` workflows from forks. The `AAP_CERTIFIED_TOKEN` and `AAP_VALIDATED_TOKEN` secrets are empty, so `ansible-galaxy` cannot download Red Hat certified collections (`ansible.controller`, etc.), and the build fails. This has been broken for months (8 of last 10 CI runs failed).

Additionally, the dispatch workflow (`build-ee-dispatch.yml`) was missing the AAP token secrets entirely, so manual builds would hit the same failure.

## Changes

- **`build-ee-pr.yml`**: Switch from `pull_request` to `pull_request_target` trigger. This runs the workflow in the base repo context where secrets are available. Uses the `ee-build` environment (already created) with required reviewer approval so a maintainer can inspect the PR diff before the build runs with secrets.
- **`build-ee.yml`**: Add optional `ref` and `environment` inputs to support the PR workflow without breaking existing callers.
- **`build-ee-dispatch.yml`**: Add missing `aap_certified_token` and `aap_validated_token` secret passthrough.

## Maintainer setup

The `ee-build` environment has already been created with @wkulhanek as the required reviewer. No additional setup needed — just merge this PR.

## How it works after merge

1. Fork PR opened that touches `tools/execution_environments/ee-multicloud-public/**`
2. Build shows "Waiting for review" in the PR checks
3. Maintainer reviews the PR diff, clicks "Approve and deploy"
4. Build runs with full secrets, complete image with certified collections is produced
5. Image pushed as `quay.io/agnosticd/ee-multicloud:chained-temporary-pr-NNN`

## Security

`pull_request_target` runs the workflow YAML from the **base branch** (not the PR), so the PR author cannot modify the workflow to exfiltrate secrets. The environment approval step gives the maintainer a chance to review Containerfile changes before the build runs.