### PR TITLE
Add acl to common packages for ansible-core 2.20 become_user

### DIFF
--- a/ansible/roles/host_common_packages/defaults/main.yml
+++ b/ansible/roles/host_common_packages/defaults/main.yml
@@ -19,6 +19,7 @@ host_common_packages_el9:
 - httpd-tools
 - tree
 - jq
+- acl
 
 # Common Packages to install for RHEL 10
 host_common_packages_el10:
@@ -34,6 +35,7 @@ host_common_packages_el10:
 - httpd-tools
 - tree
 - jq
+- acl
 
 # Extra packages to install in addition to common packages
 host_common_packages_extra: []


### PR DESCRIPTION
## Summary

- Add `acl` package to both `host_common_packages_el9` and `host_common_packages_el10` default lists

## Problem

ansible-core 2.20 (shipped in `ee-multicloud:chained-2026-04-01`) changed how temporary file permissions work when using `become_user` to switch to an unprivileged user. Without the `acl` package installed on target hosts, Ansible cannot use `setfacl` and falls back to `chgrp`/`chmod` which fail:

- RHEL 9: `chgrp: changing group of '/var/tmp/ansible-tmp-...': Operation not permitted`
- RHEL 10: `chmod: invalid mode: 'A+user:lab-user:rx:allow'`

This breaks any role that uses `become_user` for an unprivileged user, including `rhpds.rhel_management.mcp_host`.

## Fix

Installing `acl` provides `setfacl`, which is Ansible's preferred (and working) method for setting temp file permissions when becoming an unprivileged user. Since `host_common_packages` runs early in the play, all subsequent roles benefit.

## Affected catalog items

- `summit-2026.lb1305-ai-powered-rhel-mgmt-cnv` (confirmed failing on event1 and prod-us-west-2)
- Any catalog item using `become_user` with an unprivileged user on RHEL 9/10

## References

- https://docs.ansible.com/ansible-core/2.20/playbook_guide/playbooks_privilege_escalation.html#risks-of-becoming-an-unprivileged-user