### PR TITLE
namespace destroy: skip workload removal when cluster DNS returns NXDOMAIN

### DIFF
--- a/ansible/configs/namespace/destroy_env.yml
+++ b/ansible/configs/namespace/destroy_env.yml
@@ -21,19 +21,25 @@
     ansible.builtin.set_fact:
       _cluster_api_hostname: "{{ sandbox_openshift_api_url | urlsplit('hostname') }}"
 
-  - name: Check DNS resolution for cluster API
+  - name: Check cluster API reachability
     when: _cluster_api_hostname | default('') | length > 0
-    ansible.builtin.command:
-      cmd: "getent hosts {{ _cluster_api_hostname }}"
-    register: _dns_check
+    ansible.builtin.uri:
+      url: "https://{{ _cluster_api_hostname }}:6443/healthz"
+      validate_certs: false
+      timeout: 10
+    register: _cluster_check
     failed_when: false
-    changed_when: false
+
+  - name: Set cluster reachable flag
+    ansible.builtin.set_fact:
+      _cluster_unreachable: >-
+        {{ _cluster_check is defined
+           and _cluster_check is not skipped
+           and (_cluster_check.status | default(-1) | int) == -1
+           and 'Name or service not known' in (_cluster_check.msg | default('')) }}
 
   - name: Skip destroy - cluster DNS does not resolve (NXDOMAIN)
-    when:
-    - _dns_check is defined
-    - _dns_check.rc is defined
-    - _dns_check.rc != 0
+    when: _cluster_unreachable | bool
     ansible.builtin.debug:
       msg: >-
         Cluster API {{ _cluster_api_hostname }} does not resolve (NXDOMAIN).
@@ -43,7 +49,7 @@
   - name: Remove namespaced workload "{{ workload_loop_var | default('None') }}"
     when:
     - _destroy_workloads | length > 0
-    - _dns_check is not defined or _dns_check.rc is not defined or _dns_check.rc == 0
+    - not (_cluster_unreachable | default(false) | bool)
     ansible.builtin.include_role:
       name: "{{ workload_loop_var }}"
       apply:

--- a/ansible/configs/namespace/destroy_env.yml
+++ b/ansible/configs/namespace/destroy_env.yml
@@ -13,8 +13,37 @@
            if (remove_workloads | default([]) | length > 0)
            else (workloads | default([]) | reverse | list) }}
 
+  # Pre-flight DNS check: if the cluster API hostname returns NXDOMAIN,
+  # the cluster has been decommissioned and all tenant resources are gone.
+  # Skip workload removal entirely and let the destroy succeed.
+  - name: Extract cluster API hostname for DNS check
+    when: sandbox_openshift_api_url is defined
+    ansible.builtin.set_fact:
+      _cluster_api_hostname: "{{ sandbox_openshift_api_url | urlsplit('hostname') }}"
+
+  - name: Check DNS resolution for cluster API
+    when: _cluster_api_hostname | default('') | length > 0
+    ansible.builtin.command:
+      cmd: "getent hosts {{ _cluster_api_hostname }}"
+    register: _dns_check
+    failed_when: false
+    changed_when: false
+
+  - name: Skip destroy - cluster DNS does not resolve (NXDOMAIN)
+    when:
+    - _dns_check is defined
+    - _dns_check.rc is defined
+    - _dns_check.rc != 0
+    ansible.builtin.debug:
+      msg: >-
+        Cluster API {{ _cluster_api_hostname }} does not resolve (NXDOMAIN).
+        The cluster has been decommissioned and all tenant resources are gone.
+        Skipping workload removal.
+
   - name: Remove namespaced workload "{{ workload_loop_var | default('None') }}"
-    when: _destroy_workloads | length > 0
+    when:
+    - _destroy_workloads | length > 0
+    - _dns_check is not defined or _dns_check.rc is not defined or _dns_check.rc == 0
     ansible.builtin.include_role:
       name: "{{ workload_loop_var }}"
       apply:


### PR DESCRIPTION
## Summary
- Adds a pre-flight DNS check to `namespace/destroy_env.yml` before workload removal
- If the cluster API hostname returns NXDOMAIN, skips all workload removal and lets the destroy complete successfully
- Only NXDOMAIN triggers the skip - connection refused or timeouts still proceed normally

## Problem
When a shared OCP cluster is decommissioned, tenant AnarchySubjects get stuck in `destroy-failed` because the destroy playbook tries to connect to the cluster API to clean up resources (ArgoCD apps, namespaces, Keycloak users), but the cluster no longer exists.

This was observed after Summit 2026 shared clusters (`cluster-tdsqt`, `cluster-bvtt6`, `cluster-bmzsl`) were torn down while 9 tenant subjects still existed. The tenant destroys have been retrying and failing for days, each time hitting DNS resolution failures.

## How it works
1. Extracts the hostname from `sandbox_openshift_api_url`
2. Runs `getent hosts` to check DNS resolution
3. If NXDOMAIN (rc != 0): logs a message and skips workload removal - the destroy succeeds
4. If DNS resolves (rc == 0): proceeds with normal workload removal
5. If `sandbox_openshift_api_url` is not defined: proceeds normally (no behavior change)

## Test plan
- [ ] Verify destroy completes successfully when cluster API returns NXDOMAIN
- [ ] Verify destroy proceeds normally when cluster API resolves
- [ ] Verify no behavior change when `sandbox_openshift_api_url` is not defined