### PR TITLE
agnosticd_restore_output_dir: fix tar ownership error in EE containers

### DIFF
--- a/ansible/roles/agnosticd_restore_output_dir/tasks/main.yml
+++ b/ansible/roles/agnosticd_restore_output_dir/tasks/main.yml
@@ -51,6 +51,7 @@
       dest: "{{ output_dir }}"
       extra_opts:
       - --strip-components=1
+      - --no-same-owner
 
   - name: Remove archive file from output_dir
     ansible.builtin.file:


### PR DESCRIPTION
## Summary
- Add `--no-same-owner` to `unarchive` extra_opts when restoring output_dir archives from S3
- Mirrors the same fix applied to redhat-cop/agnosticd in PR #9765

## Problem
When the output_dir archive is created on a bastion VM running inside OpenShift (KubeVirt/CNV), the files in the archive are owned by OCP's random high UID (e.g. `1001430000`). When the destroy job later restores this archive in an EE container, `gtar` fails with `Cannot change ownership to uid 1001430000: Invalid argument`.

This only affects CNV-based configs where the bastion runs inside OCP with a high random UID. Most configs (EC2/cloud VMs) have normal UIDs and are unaffected.

## Fix
`--no-same-owner` tells `gtar` to use the current user's ownership. Safe for all configs - no-op for normal UIDs.

## Test plan
- [ ] Verify destroy completes past archive restore for CNV-based configs
- [ ] Verify no behavior change for standard configs