### PR TITLE
Pin ansible-core to 2.18.x — avoid 2.19 native Jinja breakage

### DIFF
--- a/tools/execution_environments/ee-multicloud-public/requirements.txt
+++ b/tools/execution_environments/ee-multicloud-public/requirements.txt
@@ -1,4 +1,8 @@
-ansible-core
+# Pin ansible-core to 2.18.x — ansible-core 2.19+ enforces native Jinja mode
+# which breaks string-to-dict coercion used in cloud provider collections.
+# See: https://docs.ansible.com/projects/ansible/latest/porting_guides/porting_guide_core_2.19.html
+# TODO: unpin after cloud provider collections are updated for native Jinja.
+ansible-core>=2.18,<2.19
 ansible-runner
 ansible-specdoc
 boto3>=1.18.0


### PR DESCRIPTION
## Summary

Pin `ansible-core>=2.18,<2.19` in the chained EE requirements to avoid breaking changes introduced in ansible-core 2.19.

## Problem

ansible-core 2.19 made native Jinja mode mandatory and removed the implicit string-to-dict literal evaluation pass ([porting guide](https://docs.ansible.com/projects/ansible/latest/porting_guides/porting_guide_core_2.19.html)). This breaks cloud provider collections that define variables as Python dict literal strings, e.g.:

```yaml
_config: >-
  {'cniVersion':'0.3.1','type':'ovn-k8s-cni-overlay', ...}
```

Previously ansible would coerce this string into a dict. With 2.19+, it stays a string and `| to_json` wraps it in quotes instead of serializing the dict. This causes failures like the Multus webhook rejecting the config as "not in JSON format."

The unpinned `requirements.txt` pulled ansible-core 2.20 on recent builds, hitting these issues across multiple cloud provider collections.

## Fix

Pin to `ansible-core>=2.18,<2.19` which:
- Matches the ansible-core version on bare-metal controllers (us-east-2, us-west-2)
- Avoids the native Jinja breakage
- Gives time to update cloud provider collections to use proper YAML dicts

## TODO after merge

1. Rebuild the EE via dispatch workflow with the new pin
2. Update cloud provider collections to use YAML dicts instead of string literals (tracked separately)
3. Unpin ansible-core once collections are fixed