### PR TITLE
fix: add galaxy.yml to agnosticd.core collection

### DIFF
--- a/ansible/collections/ansible_collections/agnosticd/core/galaxy.yml
+++ b/ansible/collections/ansible_collections/agnosticd/core/galaxy.yml
@@ -1,0 +1,19 @@
+---
+namespace: agnosticd
+name: core
+version: 1.0.0
+readme: README.md
+authors:
+- AgnosticD Team
+description: >-
+  Core plugins for AgnosticD — agnosticd_user_info module and
+  agnosticd_user_data lookup used across AgnosticD workloads.
+license:
+- GPL-2.0-or-later
+tags:
+- infrastructure
+repository: https://github.com/agnosticd/agnosticd-v2
+homepage: https://github.com/agnosticd/agnosticd-v2
+issues: https://github.com/agnosticd/agnosticd-v2/issues
+dependencies: {}
+build_ignore: []


### PR DESCRIPTION
## Problem

`agnosticd.core` contains `agnosticd_user_info` and `agnosticd_user_data`
plugins used by `agnosticd.showroom` and other collections, but had no
`galaxy.yml`. This prevented it from being installed as a standalone
collection via `ansible-galaxy collection install`, forcing all consumers
to rely on the collection being pre-baked into the execution environment.

This causes failures in environments like agdv1 where `agnosticd.core`
is not on the collections path:

```
ERROR! couldn't resolve module/action 'agnosticd.core.agnosticd_user_info'
```

## Fix

Add a minimal `galaxy.yml` to `ansible/collections/ansible_collections/agnosticd/core/`
making it a proper installable collection.

## Follow-up

A companion PR to `agnosticd/showroom` will declare `agnosticd.core` as
a formal dependency in `showroom/galaxy.yml`, so it is automatically
installed alongside the showroom collection.