### PR TITLE
fix: fall back to workloads list when remove_workloads is empty

### DIFF
--- a/ansible/configs/openshift-workloads/destroy_env.yml
+++ b/ansible/configs/openshift-workloads/destroy_env.yml
@@ -5,13 +5,15 @@
   become: false
   gather_facts: false
   tasks:
-  - name: Check that remove_workloads is a list
-    when: remove_workloads is not defined or remove_workloads is not sequence
-    ansible.builtin.fail:
-      msg: "remove_workloads variable is either not defined or is not a list"
+  - name: Set destroy workload list
+    ansible.builtin.set_fact:
+      _remove_workloads: >-
+        {{ remove_workloads
+           if (remove_workloads | default([]) | length > 0)
+           else (workloads | default([]) | reverse | list) }}
 
   - name: Set workloads to remove in standard format
-    loop: "{{ remove_workloads }}"
+    loop: "{{ _remove_workloads }}"
     loop_control:
       label: "{{ _workload.name }} on {{ _clusters | join(',') }}"
     vars:
@@ -21,8 +23,8 @@
       _workloads: >-
         {{ _workloads | default([]) + [_workload | combine({"clusters": _clusters})] }}
 
-  - name: Destroy remove_workloads on cluster(s) using optimized destroyer role
-    when: remove_workloads | length > 0
+  - name: Destroy workloads on cluster(s) using optimized destroyer role
+    when: _remove_workloads | length > 0
     ansible.builtin.include_role:
       name: openshift_workload_destroyer
     vars:


### PR DESCRIPTION
## Summary

- The `openshift-workloads` destroy playbook silently skipped all workload removal because `remove_workloads` defaults to `[]` and is rarely set explicitly in config vars
- Added fallback: when `remove_workloads` is empty, use `workloads` in reverse order (dependency-safe teardown)
- Matches the pattern already established in the `namespace` config's `destroy_env.yml`
