### PR TITLE
Fix CSR approval deadlock in assisted installer scale-up

### DIFF
--- a/ansible/roles/host_ocp4_assisted_scale/defaults/main.yml
+++ b/ansible/roles/host_ocp4_assisted_scale/defaults/main.yml
@@ -19,6 +19,6 @@ ai_configure_hosts: []
 # When true, remove worker role from control-plane nodes and mark masters non-schedulable
 worker_only: false
 
-# CSR approval retry settings
-approve_csr_retries: 90
+# CSR approval retry settings — must cover install + reboot + kubelet startup
+approve_csr_retries: 180
 approve_csr_delay: 10

--- a/ansible/roles/host_ocp4_assisted_scale/tasks/main.yaml
+++ b/ansible/roles/host_ocp4_assisted_scale/tasks/main.yaml
@@ -175,6 +175,25 @@
     loop_control:
       loop_var: _index
 
+# Approve CSRs BEFORE wait_for_hosts to avoid deadlock.
+# The machine-approver rejects CSRs for assisted-installer workers
+# (no Machine API objects), so we must approve them manually.
+# Workers install OCP, reboot, then generate CSRs — approving them
+# here lets nodes join the cluster so the AI can mark hosts ready.
+- name: Initialize CSR approval iteration counter
+  ansible.builtin.set_fact:
+    approve_csr_iteration: 1
+
+- name: Approve CSR
+  ansible.builtin.include_tasks: approve_csr_nodes.yaml
+
+- name: Wait for the hosts to be ready
+  module_defaults:
+    group/k8s:
+      host: "{{ sandbox_openshift_api_url }}"
+      api_key: "{{ sandbox_openshift_api_key }}"
+      validate_certs: false
+  block:
   - name: Wait for the hosts to be ready
     rhpds.assisted_installer.wait_for_hosts:
       cluster_id: "{{ r_import_cluster.result.id }}"
@@ -183,13 +202,6 @@
       infra_env_id: "{{ newinfraenv.result.id }}"
       configure_hosts: "{{ ai_configure_hosts }}"
       wait_timeout: 600
-
-- name: Initialize CSR approval iteration counter
-  ansible.builtin.set_fact:
-    approve_csr_iteration: 1
-
-- name: Approve CSR
-  ansible.builtin.include_tasks: approve_csr_nodes.yaml
 
 - name: Configure worker-only mode
   when: worker_only | default(false) | bool


### PR DESCRIPTION
## Problem

CNV cluster provisioning fails with a 3-hour timeout for any lab using `host_ocp4_assisted_scale` to add worker nodes. Observed on LB2391 and LB2863 — all 12 worker VMs install OCP successfully, reboot, and generate kubelet CSRs, but the CSRs are never approved and the job times out.

### Root cause: deadlock between CSR approval and wait_for_hosts

The `machine-approver` operator rejects CSRs for assisted-installer workers because no `Machine` API objects exist for them (these nodes are added via assisted installer, not the Machine API). The role handles this with `approve_csr_nodes.yaml` which manually approves pending CSRs — but it runs **after** `wait_for_hosts`.

`wait_for_hosts` blocks until the assisted installer marks hosts as "ready", which requires nodes to join the cluster, which requires CSR approval → **deadlock**.

```
wait_for_hosts (blocks)  →  needs nodes to join cluster
                             →  needs CSR approval
                                →  runs AFTER wait_for_hosts  ← deadlock
```

### Evidence from cluster-lsrl5 (LB2391)

- 12 worker VMs: all `Running` on CNV host, OCP installed successfully
- 209 pending CSRs, 0 approved (for 5+ hours)
- `machine-approver` logs: `failed to find machine with InternalDNS matching worker-cluster-lsrl5-3, cannot approve`
- Manually approving CSRs → all 12 workers joined and went `Ready` within 60 seconds
- Tower job 28088 on event0: ran for 10803s, killed by 10800s timeout

## Fix

1. **Move CSR approval before `wait_for_hosts`** — the `approve_csr_nodes.yaml` task already has a retry loop that waits for the expected number of ready worker nodes. Running it first lets CSRs get approved as workers come up, so by the time `wait_for_hosts` runs, nodes have already joined.

2. **Increase `approve_csr_retries` from 90 to 180** (15 min → 30 min) — CSR approval now runs before `wait_for_hosts` and needs to cover the full install + reboot + kubelet startup cycle.

## Files changed

| File | Change |
|------|--------|
| `tasks/main.yaml` | Move CSR approval block before `wait_for_hosts` |
| `defaults/main.yml` | `approve_csr_retries`: 90 → 180 |