### PR TITLE
Handle CSR approval race condition in assisted scale-up

### DIFF
--- a/ansible/roles/host_ocp4_assisted_scale/tasks/approve_csr_nodes.yaml
+++ b/ansible/roles/host_ocp4_assisted_scale/tasks/approve_csr_nodes.yaml
@@ -44,6 +44,9 @@
             ]
           }
         }
+      status_code: [200, 201]
+    register: _r_approve_csr
+    failed_when: _r_approve_csr.status >= 500
     loop: "{{ pending_csrs }}"
 
   - name: Get worker-only nodes (exclude control-plane/master)


### PR DESCRIPTION
## Problem

Follow-up to #147 (merged). LB2863 cluster provisioning failed with a different root cause than LB2391's deadlock — the CSR approval step itself crashed due to a race condition.

### What happened (LB2863, tower job 28080)

1. Worker VMs came up (45s)
2. `wait_for_hosts` passed (328s) — assisted installer completed
3. `approve_csr_nodes.yaml` ran — listed 2 pending CSRs
4. PUT to approve `csr-6m6t7` returned an error (409/422 — the `machine-approver` touched it between list and approve)
5. The task has no error handling → **entire playbook aborted**

The `machine-approver` operator runs continuously and sometimes approves or rejects a CSR in the window between when we list pending CSRs and when we PUT the approval. This is a benign race — the CSR is already handled — but the `uri` task treats any non-2xx as fatal.

## Fix

Add `failed_when: _r_approve_csr.status >= 500` and `status_code: [200, 201]` to the approval task. This way:
- 200/201: approved successfully (normal)
- 409 Conflict / 422 Unprocessable: CSR already handled by another controller (harmless, continue)
- 5xx: actual server error (fail)

## Files changed

| File | Change |
|------|--------|
| `tasks/approve_csr_nodes.yaml` | Add `failed_when` and `register` to CSR approval URI task |