### PR TITLE
fix(ee): add missing netaddr to ee-multicloud requirements.txt

### DIFF
--- a/tools/execution_environments/ee-multicloud-public/Containerfile
+++ b/tools/execution_environments/ee-multicloud-public/Containerfile
@@ -1,7 +1,7 @@
 # ----------------------------------------------------------------------------------
 # Build base image
 # ----------------------------------------------------------------------------------
-# Build 4/20 EE
+# Build 5/04 EE
 ARG EE_BASE_IMAGE="registry.access.redhat.com/ubi9/ubi:latest"
 
 # Building base

--- a/tools/execution_environments/ee-multicloud-public/readme.adoc
+++ b/tools/execution_environments/ee-multicloud-public/readme.adoc
@@ -2,6 +2,13 @@ For release cycle, see link:release_cycle.adoc[release_cycle]
 
 == Changelog ==
 
+=== chained-2026-05-04 ===
+
+* Add missing `netaddr>=0.8.0` Python library to requirements.txt
+** Required by `ansible.utils.ipaddr` filter plugin
+** Absence caused `ModuleNotFoundError` on Python 3.12 in `chained-2026-04-20`
+** Affected roles: `host_ocp4_assisted_installer` (and any other that uses `ipaddr`)
+
 === v0.1.2 ===
 
 * size: +37MiB -- 724.9 MiB total
@@ -41,7 +48,7 @@ For release cycle, see link:release_cycle.adoc[release_cycle]
 
 * Add `passlib` python module, needed for htpasswd
 * size +32M
-* link:https://gist.github.com/fridim/4cd6787ea0f8d27cc46fd9fc74573b15[ee-report diff with v0.0.16]
+* link:https://gist.github.com/fridim/4cd6787ea0f8d27cc46fd9fc74573b15[ee-report diff with v0.0.17]
 * link:https://gist.github.com/fridim/c89614dfec5609f56ae881ddc5fc0f90[full ee-report]
 
 === v0.0.16 ===

--- a/tools/execution_environments/ee-multicloud-public/requirements.txt
+++ b/tools/execution_environments/ee-multicloud-public/requirements.txt
@@ -9,6 +9,7 @@ dumb-init
 jmespath-community
 jsonpatch
 kubernetes>=12.0.0
+netaddr>=0.8.0
 ncclient
 packet-python>=1.43.1
 passlib[bcrypt]


### PR DESCRIPTION
## Problem

`chained-2026-04-20` regressed: `netaddr` is missing from Python 3.12, breaking the `ansible.utils.ipaddr` filter plugin.

**Verified missing:**
```
podman run --entrypoint="" quay.io/agnosticd/ee-multicloud:chained-2026-04-20 \
  python3.12 -c "import netaddr"
→ ModuleNotFoundError: No module named 'netaddr'
```

**Symptom in jobs:**
```
[ERROR]: Task failed: Finalization of task args for 'community.general.nsupdate' failed:
Error while resolving value for 'server': The filter plugin 'ansible.utils.ipaddr' failed:
Failed to import the required Python library (netaddr) on Python /usr/bin/python3.12.
```

Affected role: `host_ocp4_assisted_installer` (task: `Add A dns record - masters`).

## Fix

- Add `netaddr>=0.8.0` to `requirements.txt` (alphabetically ordered after `ncclient`)
- Update `Containerfile` build comment to `5/04 EE`
- Add changelog entry in `readme.adoc`

## After merge

Whoever triggers the dispatch workflow should tag it `chained-2026-05-04`.
