### PR TITLE
fix: cleanup scaled worker namespaces on assisted installer destroy

### DIFF
--- a/ansible/roles/host_ocp4_assisted_destroy/tasks/main.yaml
+++ b/ansible/roles/host_ocp4_assisted_destroy/tasks/main.yaml
@@ -16,88 +16,119 @@
   vars:
     _cluster_name: "cluster-{{ guid }}-{{ extra_sno_cluster.name }}"
 
-- name: Destroy OpenShift using Assisted Installer
-  module_defaults:
-    group/k8s:
-      host: "{{ sandbox_openshift_api_url }}"
-      api_key: "{{ k8s_auth_results.k8s_auth.api_key | default(sandbox_openshift_api_key) }}"
-      validate_certs: false
+- name: Destroy and cleanup
   block:
-  - name: Create a job to cleanup Ceph
-    kubernetes.core.k8s:
-      definition: "{{ lookup('ansible.builtin.template', 'cleanup-ceph.yaml.j2') | from_yaml }}"
-      wait: true
-      wait_timeout: 300
-    register: r_cleanup
-    retries: 3
-    delay: 10
-    ignore_errors: true
+  - name: Destroy OpenShift using Assisted Installer
+    module_defaults:
+      group/k8s:
+        host: "{{ sandbox_openshift_api_url }}"
+        api_key: "{{ k8s_auth_results.k8s_auth.api_key | default(sandbox_openshift_api_key) }}"
+        validate_certs: false
+    block:
+    - name: Create a job to cleanup Ceph
+      kubernetes.core.k8s:
+        definition: "{{ lookup('ansible.builtin.template', 'cleanup-ceph.yaml.j2') | from_yaml }}"
+        wait: true
+        wait_timeout: 300
+      register: r_cleanup
+      retries: 3
+      delay: 10
+      ignore_errors: true
 
-  - name: Delete dns records (DDNS)
-    when: cluster_dns_server is defined
-    ansible.builtin.nsupdate:
-      server: >-
-        {{ cluster_dns_server
-        | ansible.utils.ipaddr
-        | ternary(cluster_dns_server, lookup('community.general.dig', cluster_dns_server))
-        }}
-      zone: "{{ cluster_dns_zone }}"
-      record: "{{ item }}.{{ cluster_name}}"
-      type: A
-      ttl: 30
-      port: "{{ cluster_dns_port | d('53') }}"
-      key_name: "{{ ddns_key_name }}"
-      key_secret: "{{ ddns_key_secret }}"
-      key_algorithm:  hmac-sha256
-      state: absent
-    loop:
+    - name: Delete dns records (DDNS)
+      when: cluster_dns_server is defined
+      ansible.builtin.nsupdate:
+        server: >-
+          {{ cluster_dns_server
+          | ansible.utils.ipaddr
+          | ternary(cluster_dns_server, lookup('community.general.dig', cluster_dns_server))
+          }}
+        zone: "{{ cluster_dns_zone }}"
+        record: "{{ item }}.{{ cluster_name}}"
+        type: A
+        ttl: 30
+        port: "{{ cluster_dns_port | d('53') }}"
+        key_name: "{{ ddns_key_name }}"
+        key_secret: "{{ ddns_key_secret }}"
+        key_algorithm:  hmac-sha256
+        state: absent
+      loop:
+        - "api-int"
+        - "api"
+        - "*.apps"
+
+    - name: Delete DNS records (Route53)
+      when: route53_aws_access_key_id is defined
+      amazon.aws.route53:
+        state: absent
+        aws_access_key_id: "{{ route53_aws_access_key_id }}"
+        aws_secret_access_key: "{{ route53_aws_secret_access_key }}"
+        hosted_zone_id: "{{ route53_aws_zone_id }}"
+        record: "{{ item }}.{{ cluster_name }}.{{ cluster_dns_zone }}"
+        zone: "{{ cluster_dns_zone  }}"
+        type: A
+      loop:
       - "api-int"
       - "api"
       - "*.apps"
-    
-  - name: Delete DNS records (Route53)
-    when: route53_aws_access_key_id is defined
-    amazon.aws.route53:
-      state: absent
-      aws_access_key_id: "{{ route53_aws_access_key_id }}"
-      aws_secret_access_key: "{{ route53_aws_secret_access_key }}"
-      hosted_zone_id: "{{ route53_aws_zone_id }}"
-      record: "{{ item }}.{{ cluster_name }}.{{ cluster_dns_zone }}"
-      zone: "{{ cluster_dns_zone  }}"
-      type: A
-    loop:
-    - "api-int"
-    - "api"
-    - "*.apps"
-    retries: 6
-    delay: 30
-    register: r_dns_cleanup
-    until: r_dns_cleanup is success
+      retries: 6
+      delay: 30
+      register: r_dns_cleanup
+      until: r_dns_cleanup is success
 
-  - name: Get a list of clusters
-    rhpds.assisted_installer.list_clusters:
-      offline_token: "{{ ai_offline_token }}"
-      owner: true
-    register: listclusters
-
-  - name: Filter the created clusters
-    when: item.name == cluster_name
-    ansible.builtin.set_fact:
-      cluster_id: "{{ item.id }}"
-    loop: "{{ listclusters.result }}"
-    loop_control:
-      label: "{{ item.name }}"
-
-  - name: Remove Assisted Installer Cluster
-    when: cluster_id | default("") | length > 0
-    block:
-    - name: Debug cluster id and name
-      ansible.builtin.debug:
-        msg: "Cluster to be removed: Cluster ID={{ cluster_id }}, Cluster Name={{ cluster_name }}"
-
-    - name: Delete cluster in Red Hat Console
-      rhpds.assisted_installer.delete_cluster:
-        cluster_id: "{{ cluster_id }}"
+    - name: Get a list of clusters
+      rhpds.assisted_installer.list_clusters:
         offline_token: "{{ ai_offline_token }}"
+        owner: true
+      register: listclusters
 
+    - name: Filter the created clusters
+      when: item.name == cluster_name
+      ansible.builtin.set_fact:
+        cluster_id: "{{ item.id }}"
+      loop: "{{ listclusters.result }}"
+      loop_control:
+        label: "{{ item.name }}"
 
+    - name: Remove Assisted Installer Cluster
+      when: cluster_id | default("") | length > 0
+      block:
+      - name: Debug cluster id and name
+        ansible.builtin.debug:
+          msg: "Cluster to be removed: Cluster ID={{ cluster_id }}, Cluster Name={{ cluster_name }}"
+
+      - name: Delete cluster in Red Hat Console
+        rhpds.assisted_installer.delete_cluster:
+          cluster_id: "{{ cluster_id }}"
+          offline_token: "{{ ai_offline_token }}"
+
+  always:
+  - name: Cleanup scaled worker namespaces
+    module_defaults:
+      group/k8s:
+        host: "{{ sandbox_openshift_api_url }}"
+        api_key: "{{ k8s_auth_results.k8s_auth.api_key | default(sandbox_openshift_api_key) }}"
+        validate_certs: false
+    block:
+    - name: List sandbox namespaces
+      kubernetes.core.k8s_info:
+        api_version: v1
+        kind: Namespace
+        label_selectors:
+          - "created-by=sandbox-api"
+      register: r_sandbox_namespaces
+
+    - name: Delete sibling worker namespaces
+      kubernetes.core.k8s:
+        api_version: v1
+        kind: Namespace
+        name: "{{ item.metadata.name }}"
+        state: absent
+      loop: >-
+        {{ r_sandbox_namespaces.resources
+           | selectattr('metadata.name', 'match', 'sandbox-' ~ guid ~ '-\d+')
+           | list }}
+      loop_control:
+        label: "{{ item.metadata.name }}"
+      ignore_errors: true
+    ignore_errors: true


### PR DESCRIPTION
## Summary
- Wraps the existing destroy block in `block/always` to ensure cleanup runs regardless of destroy success/failure
- In the `always` section, finds sibling worker namespaces by name pattern (`sandbox-{guid}-{N}-*`) and deletes them
- Namespace deletion cascades to VMs, DataVolumes, PVCs, and PVs (Ceph storage freed via `Delete` reclaim policy)

## Problem
When `host_ocp4_assisted_scale` creates worker VMs, they live in a sibling sandbox namespace (e.g., `sandbox-k5snl-1-ocp4-cluster`) and reference a Multus NetworkAttachmentDefinition from the parent namespace (`sandbox-k5snl-ocp4-cluster`).

If the parent is destroyed first, the Multus network is deleted and the worker VMs get stuck in `Starting/Pending` with:
```
failed to render launch manifest: failed to locate network attachment definition
sandbox-k5snl-1-ocp4-cluster/cluster-k5snl-openshift
```

No destroy job runs for the worker namespace, orphaning VMs, DataVolumes, and ~202Gi of Ceph PVCs per instance.

Observed on `ocpv01.dfw3` with LB1839 (balance-virt-fallback) guid `k5snl-1`.

## Test plan
- [ ] Verify YAML syntax passes (`ansible-playbook --syntax-check`)
- [ ] Verify the `always` block runs after both successful and failed destroys
- [ ] Verify the Jinja `match` filter correctly identifies sibling namespaces (`sandbox-{guid}-1-*`) but not the parent (`sandbox-{guid}-*`)
- [ ] Test with a scaled cluster destroy to confirm worker namespace and resources are cleaned up