### PR TITLE
[host_ocp4_assisted_scale] Update machine type to pc-q35-rhel9.2.0

### DIFF
--- a/ansible/roles/host_ocp4_assisted_scale/tasks/create_workers.yaml
+++ b/ansible/roles/host_ocp4_assisted_scale/tasks/create_workers.yaml
@@ -133,7 +133,7 @@
           interfaces: {{ _instance_interfaces }}
           networkInterfaceMultiqueue: true
         machine:
-          type: pc-q35-rhel8.6.0
+          type: pc-q35-rhel9.2.0
         memory:
           guest: "{{ ai_workers_memory }}"
       readinessProbe:


### PR DESCRIPTION
##### SUMMARY

Avoid warnings related to cpu type on kubevirt, such as:
```
Virtual Machine 'worker-cluster-jtbsc-4' in namespace 'Namespace
NS
[sandbox-jtbsc-ocp4-cluster]
' is using machine type 'pc-q35-rhel8.6.0', which is deprecated. Current status: 'running'.

```
##### ISSUE TYPE

- Feature Pull Request


##### COMPONENT NAME
host_ocp4_assisted_scale role
