### PR TITLE
Fix worker SVC name mismatch in host_ocp4_assisted_scale

### DIFF
--- a/ansible/roles/host_ocp4_assisted_scale/defaults/main.yml
+++ b/ansible/roles/host_ocp4_assisted_scale/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 cluster_name: "cluster-{{ guid.split('-')[0] if '-' in guid else guid }}"
+_cluster_name: "{{ cluster_name }}"
 ocp4_pull_secret: "{{ ocp4_ai_pull_secret }}"
 
 ai_pull_secret: "{{ ocp4_pull_secret | to_json | to_json if ocp4_pull_secret is mapping else ocp4_pull_secret | to_json }}"

--- a/ansible/roles/host_ocp4_assisted_scale/tasks/main.yaml
+++ b/ansible/roles/host_ocp4_assisted_scale/tasks/main.yaml
@@ -48,7 +48,7 @@
     kubernetes.core.k8s:
       state: patched
       kind: Service
-      name: "{{ ai_ocp_vmname_worker_prefix }}-svc"
+      name: "{{ ai_ocp_vmname_worker_prefix }}-svc-{{ _cluster_name }}"
       namespace: "{{ ai_ocp_namespace }}"
       api_version: v1
       merge_type: merge


### PR DESCRIPTION
## Summary

- Fix service name mismatch between `host_ocp4_assisted_installer` (provisioning) and `host_ocp4_assisted_scale` (day-2 scaling) that breaks ingress routing on compact clusters after workers are added

## Root cause

The multi-SNO support refactor (#152) changed LB service names in `configure_sno_compact_cluster.yml` from `{{ prefix }}-svc` to `{{ prefix }}-svc-{{ _cluster_name }}`, but `host_ocp4_assisted_scale` was never updated to match.

When the scale role runs on a compact cluster provisioned with `main`:

1. Provisioning creates worker service: `worker-cluster-GUID-svc-cluster-GUID`
2. Scale role looks for: `worker-cluster-GUID-svc` → **not found** (silent warning)
3. Scale role removes worker label from control planes, reschedules ingress to workers
4. `*.apps` DNS still points to control plane LB → control planes no longer run ingress → **Connection refused** on all routes

This was confirmed by comparing two real deployments:
- `dynamic2` pool (uses `main` branch) → service name mismatch → all routes unreachable after scaling
- `dyn` pool (uses `ocp-cnv-pool-1.2.0` tag, pre-refactor) → names match → works

## Changes

- Add `_cluster_name` default to `host_ocp4_assisted_scale` (matching `host_ocp4_assisted_installer`)
- Update worker SVC name to include `_cluster_name` suffix

## Impact

- **Compact clusters on `main`**: fixes the ingress routing breakage
- **Full clusters**: unaffected (the SVC update task is skipped when `current_instance_workers > 0`)
- **Old tags** (`ocp-cnv-pool-1.2.0`): unaffected (both provisioning and scaling use old naming)