### PR TITLE
Fix virtctl install failure on RHEL 10 bastions (ABI)

### DIFF
--- a/ansible/roles/host_ocp4_assisted_installer/tasks/setup_infrastructure_abi.yml
+++ b/ansible/roles/host_ocp4_assisted_installer/tasks/setup_infrastructure_abi.yml
@@ -112,13 +112,30 @@
     ansible.builtin.command:
       cmd: "/usr/bin/openshift-install agent create image --dir ~{{ ansible_user }}/{{ cluster_name }}/ocp-cluster/"
 
-  # TODO: fix
   - name: Download virtctl
-    become: true
     ansible.builtin.get_url:
       url: https://github.com/kubevirt/kubevirt/releases/download/v1.7.3/virtctl-v1.7.3-linux-amd64
+      dest: /tmp/virtctl
+      mode: '0644'
+    register: r_virtctl
+    until: r_virtctl is success
+    retries: 5
+    delay: 10
+
+  - name: Install virtctl to /usr/bin
+    become: true
+    ansible.builtin.copy:
+      src: /tmp/virtctl
+      remote_src: true
       dest: /usr/bin/virtctl
       mode: '0755'
+      owner: root
+      group: root
+
+  - name: Remove downloaded virtctl temp file
+    ansible.builtin.file:
+      state: absent
+      path: /tmp/virtctl
 
   - name: Create a DataVolume
     ansible.builtin.command: |


### PR DESCRIPTION
## Summary

- Fix `Download virtctl` task that fails with `Destination /usr/bin is not writable` on RHEL 10 bastion VMs
- Split single `get_url` into download-to-tmp + privileged-copy, matching the pattern in the non-ABI `setup_infrastructure.yml`
- Add download retries for transient network errors

## Problem

The `openshift-4.20-multi-dev` pool on prod-us-east-2 is failing at a **94% provision failure rate** (vs 2.7% normal), generating ~900 extra jobs/day in a retry loop. The root cause is `ansible.builtin.get_url` with `become: true` inside a `delegate_to` block — privilege escalation doesn't propagate to the file copy step on RHEL 10 bastions, so `cloud-user` can't write to `/usr/bin`.

## Impact

- Monday June 1: 1,326 CNV pool jobs (vs ~470 normal) — 444 failed provisions
- Today June 2: 243+ failed provisions, **zero successful** from the dev pool
- The retry storm also drives ~1,000 extra project-update (SCM sync) jobs per day

## Test plan

- [ ] Verify a dev pool provision completes the `Download virtctl` + `Install virtctl to /usr/bin` tasks
- [ ] Verify `virtctl` is executable at `/usr/bin/virtctl` on the bastion after install
- [ ] Verify the `Create a DataVolume` task (next step) succeeds using the installed `virtctl`