### PR TITLE
fix(ee): guard install_dynamic_dependencies.yml on file existence

### DIFF
--- a/tools/execution_environments/ee-multicloud-public/Containerfile
+++ b/tools/execution_environments/ee-multicloud-public/Containerfile
@@ -60,6 +60,27 @@ COPY requirements.yml /tmp/requirements.yml
 # RUN echo Validated Token: ${AAP_VALIDATED_TOKEN}
 # RUN echo --------------------------------------------------
 
+# Fail fast if Automation Hub tokens are missing or expired
+RUN if [ "${AAP_CERTIFIED_TOKEN}" = "notset" ] || [ -z "${AAP_CERTIFIED_TOKEN}" ]; then \
+      echo "ERROR: AAP_CERTIFIED_TOKEN is not set. Generate a new token at:"; \
+      echo "  https://console.redhat.com/ansible/automation-hub/token"; \
+      echo "Then update the GitHub secret and re-run the build."; \
+      exit 1; \
+    fi && \
+    HTTP_CODE=$(curl -s -o /dev/null -w '%{http_code}' \
+      --data-urlencode "grant_type=refresh_token" \
+      --data-urlencode "client_id=cloud-services" \
+      --data-urlencode "refresh_token=${AAP_CERTIFIED_TOKEN}" \
+      https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token) && \
+    if [ "$HTTP_CODE" != "200" ]; then \
+      echo "ERROR: Automation Hub token is expired or invalid (HTTP $HTTP_CODE)."; \
+      echo "Generate a new token at: https://console.redhat.com/ansible/automation-hub/token"; \
+      echo "Then update AAP_CERTIFIED_TOKEN and AAP_VALIDATED_TOKEN in GitHub secrets."; \
+      exit 1; \
+    else \
+      echo "Automation Hub token validated successfully."; \
+    fi
+
 # Set tokens as environment variables for ansible-galaxy to use with the configured servers
 ENV ANSIBLE_GALAXY_SERVER_CERTIFIED_TOKEN=${AAP_CERTIFIED_TOKEN}
 ENV ANSIBLE_GALAXY_SERVER_VALIDATED_TOKEN=${AAP_VALIDATED_TOKEN}

--- a/tools/execution_environments/ee-multicloud-public/Containerfile
+++ b/tools/execution_environments/ee-multicloud-public/Containerfile
@@ -66,10 +66,10 @@ ENV ANSIBLE_GALAXY_SERVER_VALIDATED_TOKEN=${AAP_VALIDATED_TOKEN}
 
 RUN ansible-galaxy role install -r /tmp/requirements.yml --roles-path "/usr/share/ansible/roles"
 RUN for i in 1 2 3; do \
-      ansible-galaxy collection install -vv -r /tmp/requirements.yml --collections-path "/usr/share/ansible/collections" && break || \
+      ansible-galaxy collection install -vv --no-cache -r /tmp/requirements.yml --collections-path "/usr/share/ansible/collections" && break || \
       { echo "Attempt $i failed. Retrying in 5 seconds..."; sleep 5; }; \
     done && \
-    ansible-galaxy collection list --collections-path "/usr/share/ansible/collections" || \
+    ansible-galaxy collection list --collections-path "/usr/share/ansible/collections" | grep -q ansible.controller || \
     { echo "Failed to install collections after 3 attempts"; exit 1; }
 
 # ----------------------------------------------------------------------------------

--- a/tools/execution_environments/ee-multicloud-public/entrypoint.sh
+++ b/tools/execution_environments/ee-multicloud-public/entrypoint.sh
@@ -236,13 +236,21 @@ done
 # Execute based on AAP detection
 if (( AAP == 1 )); then
   log_debug "AAP environment detected. Running with fixed extra-vars"
-  /usr/local/bin/ansible-playbook ./ansible/install_dynamic_dependencies.yml -i /runner/inventory/hosts -e @/runner/env/extravars
+  if [ -f "${INSTALL_PLAYBOOK}" ]; then
+    /usr/local/bin/ansible-playbook "${INSTALL_PLAYBOOK}" -i /runner/inventory/hosts -e @/runner/env/extravars
+  else
+    log_debug "Install playbook ${INSTALL_PLAYBOOK} not found, skipping dynamic dependency install"
+  fi
 else
   # Only shift in non-AAP context -> Ansible Navigator
   shift 2
   log_debug "Non-AAP environment. Running with processed arguments"
   log_debug "Remaining arguments: $*"
-  /usr/local/bin/ansible-playbook ./ansible/install_dynamic_dependencies.yml "$@"
+  if [ -f "${INSTALL_PLAYBOOK}" ]; then
+    /usr/local/bin/ansible-playbook "${INSTALL_PLAYBOOK}" "$@"
+  else
+    log_debug "Install playbook ${INSTALL_PLAYBOOK} not found, skipping dynamic dependency install"
+  fi
 fi
 
 # Chain exec original command


### PR DESCRIPTION
## Summary

- Add `[ -f ]` file-existence check before running `install_dynamic_dependencies.yml` in the AAP execution node and ansible-navigator entrypoint paths
- Matches the existing guard in the Kubernetes/container-group path (line 209)
- Uses the `INSTALL_PLAYBOOK` variable instead of hardcoding the path

## Problem

The EE entrypoint runs `install_dynamic_dependencies.yml` before the real playbook. This file only exists in agnosticd-v2 projects. When the EE is used with agnosticd v1 projects on **standalone AAP controllers** (execution nodes), every job fails immediately with:

```
ERROR! the playbook: ./ansible/install_dynamic_dependencies.yml could not be found
```

The Kubernetes/container-group code path already handles this gracefully with a `[ -f ]` check (line 209), but the AAP execution node and ansible-navigator paths do not.

## Impact

- **Standalone AAP** (e.g. prod-us-west-2): All jobs using this EE with agnosticd v1 projects fail — blocks all `osp-on-ocp-cnv` provisioning
- **OCP container groups**: Unaffected (already guarded)

## Test plan

- [ ] Build EE from this branch and run an agnosticd v1 job on a standalone AAP controller
- [ ] Verify agnosticd v2 jobs with `install_dynamic_dependencies.yml` still run the dependency install
- [ ] Verify OCP container group jobs are unaffected