### PR TITLE
feat: replace MinIO with S4 for dedicated Troshka instances

### DIFF
--- a/ansible/roles/ocp4_workload_troshka_dedicated/defaults/main.yaml
+++ b/ansible/roles/ocp4_workload_troshka_dedicated/defaults/main.yaml
@@ -1,0 +1,34 @@
+---
+# Action: provision or remove
+ACTION: provision
+
+# Namespace (set by agnosticv, typically guid-based)
+troshka_namespace: "troshka-{{ guid }}"
+
+# Container images
+troshka_backend_image: "quay.io/redhat-gpte/troshka-backend:latest"
+troshka_frontend_image: "quay.io/redhat-gpte/troshka-frontend:latest"
+
+# Host VM defaults (overridden by agnosticv parameters)
+troshka_host_vcpus: 16
+troshka_host_memory_gb: 64
+troshka_host_disk_gb: 200
+
+# Central image repo (S4)
+troshka_seed_s3_endpoint: ""
+troshka_seed_s3_bucket: "troshka-gold-images"
+troshka_seed_s3_access_key: ""
+troshka_seed_s3_secret_key: ""
+troshka_seed_images: []
+
+# Resource limits
+troshka_backend_cpu_request: "250m"
+troshka_backend_memory_limit: "2Gi"
+troshka_frontend_cpu_request: "100m"
+troshka_frontend_memory_limit: "512Mi"
+
+# Database
+troshka_postgres_pvc_size: "10Gi"
+
+# S4
+troshka_s4_pvc_size: "50Gi"

--- a/ansible/roles/ocp4_workload_troshka_dedicated/tasks/backend.yaml
+++ b/ansible/roles/ocp4_workload_troshka_dedicated/tasks/backend.yaml
@@ -1,0 +1,132 @@
+---
+- name: Get cluster apps domain
+  kubernetes.core.k8s_info:
+    api_version: config.openshift.io/v1
+    kind: Ingress
+    name: cluster
+  register: _ingress_config
+
+- name: Set cluster apps domain
+  ansible.builtin.set_fact:
+    _cluster_apps_domain: "{{ _ingress_config.resources[0].spec.domain }}"
+    _troshka_route_host: "troshka-{{ troshka_namespace }}.{{ _ingress_config.resources[0].spec.domain }}"
+
+- name: Set requester identity
+  ansible.builtin.set_fact:
+    _requester_identity: "{{ requester_email | default(user) | default('admin@troshka') }}"
+
+- name: Create backend ConfigMap
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: troshka-config
+        namespace: "{{ troshka_namespace }}"
+      data:
+        config.yaml: |
+          app:
+            port: 8200
+            host: "0.0.0.0"
+            log_level: info
+            external_url: "https://{{ _troshka_route_host }}"
+          auth:
+            oauth_enabled: true
+            admin_users: "{{ _requester_identity }}"
+            allowed_users: "{{ _requester_identity }}"
+            operator_users: ""
+          s3:
+            endpoint_url: "http://troshka-s4.{{ troshka_namespace }}.svc:7480"
+            bucket: "troshka-images"
+            region: "us-east-1"
+          defaults:
+            run_timer_hours: 8
+            lifetime_days: 30
+            max_vms_per_project: 20
+            max_projects_per_user: 10
+            user_library_quota_gb: 500
+          overcommit:
+            cpu_ratio: 4.0
+            ram_ratio: 1.5
+
+- name: Deploy backend
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: troshka-backend
+        namespace: "{{ troshka_namespace }}"
+        labels:
+          app.kubernetes.io/name: troshka-backend
+      spec:
+        replicas: 1
+        selector:
+          matchLabels:
+            app.kubernetes.io/name: troshka-backend
+        template:
+          metadata:
+            labels:
+              app.kubernetes.io/name: troshka-backend
+          spec:
+            containers:
+              - name: backend
+                image: "{{ troshka_backend_image }}"
+                ports:
+                  - containerPort: 8200
+                env:
+                  - name: TROSHKA_DATABASE__URL
+                    valueFrom:
+                      secretKeyRef:
+                        name: troshka-secrets
+                        key: database-url
+                  - name: TROSHKA_AUTH__JWT_SECRET
+                    valueFrom:
+                      secretKeyRef:
+                        name: troshka-secrets
+                        key: jwt-secret
+                  - name: TROSHKA_AUTH__ENCRYPTION_KEY
+                    valueFrom:
+                      secretKeyRef:
+                        name: troshka-secrets
+                        key: encryption-key
+                  - name: TROSHKA_S3__ACCESS_KEY_ID
+                    valueFrom:
+                      secretKeyRef:
+                        name: troshka-secrets
+                        key: s3-access-key
+                  - name: TROSHKA_S3__SECRET_ACCESS_KEY
+                    valueFrom:
+                      secretKeyRef:
+                        name: troshka-secrets
+                        key: s3-secret-key
+                volumeMounts:
+                  - name: config
+                    mountPath: /opt/app-root/src/config
+                resources:
+                  requests:
+                    cpu: "{{ troshka_backend_cpu_request }}"
+                  limits:
+                    memory: "{{ troshka_backend_memory_limit }}"
+            volumes:
+              - name: config
+                configMap:
+                  name: troshka-config
+
+- name: Create backend Service
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: troshka-backend
+        namespace: "{{ troshka_namespace }}"
+      spec:
+        selector:
+          app.kubernetes.io/name: troshka-backend
+        ports:
+          - port: 8200
+            targetPort: 8200

--- a/ansible/roles/ocp4_workload_troshka_dedicated/tasks/configure.yaml
+++ b/ansible/roles/ocp4_workload_troshka_dedicated/tasks/configure.yaml
@@ -1,0 +1,89 @@
+---
+- name: Wait for backend to be ready
+  ansible.builtin.uri:
+    url: "http://troshka-backend.{{ troshka_namespace }}.svc:8200/api/v1/health"
+    return_content: false
+  register: _health
+  until: _health.status == 200
+  retries: 30
+  delay: 10
+  ignore_errors: true
+
+- name: Set API auth headers (SSO header injection for server-to-server calls)
+  ansible.builtin.set_fact:
+    _api_headers:
+      Content-Type: "application/json"
+      X-Forwarded-Email: "{{ _requester_identity }}"
+      X-Forwarded-User: "{{ _requester_identity }}"
+
+- name: Get cluster API URL
+  ansible.builtin.set_fact:
+    _cluster_api_url: "{{ sandbox_openshift_api_url | default(lookup('env', 'K8S_AUTH_HOST')) }}"
+
+- name: Register OCP Virt provider
+  ansible.builtin.uri:
+    url: "http://troshka-backend.{{ troshka_namespace }}.svc:8200/api/v1/providers/"
+    method: POST
+    headers: "{{ _api_headers }}"
+    body_format: json
+    body:
+      name: "Local OCP Virt"
+      type: "ocpvirt"
+      default_region: "{{ troshka_namespace }}"
+      credentials:
+        token: "{{ _troshka_sa_token }}"
+        namespace: "{{ troshka_namespace }}"
+        api_url: "{{ _cluster_api_url }}"
+    status_code: [200, 201]
+  register: _provider
+
+- name: Register S4 storage provider
+  ansible.builtin.uri:
+    url: "http://troshka-backend.{{ troshka_namespace }}.svc:8200/api/v1/providers/"
+    method: POST
+    headers: "{{ _api_headers }}"
+    body_format: json
+    body:
+      name: "Local S4"
+      type: "s3"
+      credentials:
+        endpoint_url: "http://troshka-s4.{{ troshka_namespace }}.svc:7480"
+        access_key_id: "{{ _s4_access_key }}"
+        secret_access_key: "{{ _s4_secret_key }}"
+        bucket: "troshka-images"
+        region: "us-east-1"
+    status_code: [200, 201]
+
+- name: Create agent host
+  ansible.builtin.uri:
+    url: "http://troshka-backend.{{ troshka_namespace }}.svc:8200/api/v1/hosts/"
+    method: POST
+    headers: "{{ _api_headers }}"
+    body_format: json
+    body:
+      provider_id: "{{ _provider.json.id }}"
+      name: "dedicated-host"
+      instance_type: "custom"
+      vcpus: "{{ troshka_host_vcpus }}"
+      memory_gb: "{{ troshka_host_memory_gb }}"
+      disk_gb: "{{ troshka_host_disk_gb }}"
+    status_code: [200, 201]
+  register: _host
+
+- name: Wait for host to connect
+  ansible.builtin.uri:
+    url: "http://troshka-backend.{{ troshka_namespace }}.svc:8200/api/v1/hosts/{{ _host.json.id }}"
+    method: GET
+    headers: "{{ _api_headers }}"
+  register: _host_status
+  until: _host_status.json.state == "connected"
+  retries: 60
+  delay: 15
+
+- name: Set user info for catalog UI
+  agnosticd.core.agnosticd_user_info:
+    data:
+      troshka_url: "https://{{ _troshka_route_host }}"
+    msg: |-
+      Troshka URL: https://{{ _troshka_route_host }}
+      Login with your OpenShift credentials.

--- a/ansible/roles/ocp4_workload_troshka_dedicated/tasks/frontend.yaml
+++ b/ansible/roles/ocp4_workload_troshka_dedicated/tasks/frontend.yaml
@@ -1,0 +1,51 @@
+---
+- name: Deploy frontend
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: troshka-frontend
+        namespace: "{{ troshka_namespace }}"
+        labels:
+          app.kubernetes.io/name: troshka-frontend
+      spec:
+        replicas: 1
+        selector:
+          matchLabels:
+            app.kubernetes.io/name: troshka-frontend
+        template:
+          metadata:
+            labels:
+              app.kubernetes.io/name: troshka-frontend
+          spec:
+            containers:
+              - name: frontend
+                image: "{{ troshka_frontend_image }}"
+                ports:
+                  - containerPort: 3000
+                env:
+                  - name: BACKEND_URL
+                    value: "http://troshka-backend.{{ troshka_namespace }}.svc:8200"
+                resources:
+                  requests:
+                    cpu: "{{ troshka_frontend_cpu_request }}"
+                  limits:
+                    memory: "{{ troshka_frontend_memory_limit }}"
+
+- name: Create frontend Service
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: troshka-frontend
+        namespace: "{{ troshka_namespace }}"
+      spec:
+        selector:
+          app.kubernetes.io/name: troshka-frontend
+        ports:
+          - port: 3000
+            targetPort: 3000

--- a/ansible/roles/ocp4_workload_troshka_dedicated/tasks/main.yaml
+++ b/ansible/roles/ocp4_workload_troshka_dedicated/tasks/main.yaml
@@ -1,0 +1,18 @@
+---
+- name: Run provision tasks
+  when: ACTION == "provision" or ACTION == "create"
+  block:
+    - ansible.builtin.include_tasks: serviceaccount.yaml
+    - ansible.builtin.include_tasks: postgres.yaml
+    - ansible.builtin.include_tasks: s4.yaml
+    - ansible.builtin.include_tasks: secrets.yaml
+    - ansible.builtin.include_tasks: backend.yaml
+    - ansible.builtin.include_tasks: migrate.yaml
+    - ansible.builtin.include_tasks: frontend.yaml
+    - ansible.builtin.include_tasks: oauth.yaml
+    - ansible.builtin.include_tasks: configure.yaml
+    - ansible.builtin.include_tasks: seed.yaml
+
+- name: Run remove tasks
+  when: ACTION == "destroy" or ACTION == "remove"
+  ansible.builtin.include_tasks: remove_workload.yaml

--- a/ansible/roles/ocp4_workload_troshka_dedicated/tasks/migrate.yaml
+++ b/ansible/roles/ocp4_workload_troshka_dedicated/tasks/migrate.yaml
@@ -1,0 +1,44 @@
+---
+- name: Run database migration
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: batch/v1
+      kind: Job
+      metadata:
+        name: "troshka-migrate-{{ lookup('password', '/dev/null chars=ascii_lowercase,digits length=6') }}"
+        namespace: "{{ troshka_namespace }}"
+      spec:
+        ttlSecondsAfterFinished: 600
+        template:
+          spec:
+            restartPolicy: Never
+            containers:
+              - name: migrate
+                image: "{{ troshka_backend_image }}"
+                command: ["python3", "-m", "alembic", "upgrade", "head"]
+                env:
+                  - name: TROSHKA_DATABASE__URL
+                    valueFrom:
+                      secretKeyRef:
+                        name: troshka-secrets
+                        key: database-url
+                volumeMounts:
+                  - name: config
+                    mountPath: /opt/app-root/src/config
+            volumes:
+              - name: config
+                configMap:
+                  name: troshka-config
+  register: _migrate_job
+
+- name: Wait for migration to complete
+  kubernetes.core.k8s_info:
+    api_version: batch/v1
+    kind: Job
+    name: "{{ _migrate_job.result.metadata.name }}"
+    namespace: "{{ troshka_namespace }}"
+  register: _migrate_status
+  until: (_migrate_status.resources[0].status.succeeded | default(0)) >= 1
+  retries: 30
+  delay: 10

--- a/ansible/roles/ocp4_workload_troshka_dedicated/tasks/oauth.yaml
+++ b/ansible/roles/ocp4_workload_troshka_dedicated/tasks/oauth.yaml
@@ -1,0 +1,132 @@
+---
+- name: Annotate SA for OAuth redirect
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: troshka-sa
+        namespace: "{{ troshka_namespace }}"
+        annotations:
+          serviceaccounts.openshift.io/oauth-redirectreference.primary: >-
+            {"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"troshka"}}
+
+- name: Generate OAuth cookie secret
+  ansible.builtin.command: python3 -c "import os, base64; print(base64.b64encode(os.urandom(32)).decode())"
+  register: _cookie_secret_result
+  changed_when: false
+
+- name: Create OAuth proxy secret
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: troshka-oauth-proxy
+        namespace: "{{ troshka_namespace }}"
+      type: Opaque
+      stringData:
+        cookie-secret: "{{ _cookie_secret_result.stdout }}"
+
+- name: Deploy OAuth proxy
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: troshka-oauth-proxy
+        namespace: "{{ troshka_namespace }}"
+        labels:
+          app.kubernetes.io/name: troshka-oauth-proxy
+      spec:
+        replicas: 1
+        selector:
+          matchLabels:
+            app.kubernetes.io/name: troshka-oauth-proxy
+        template:
+          metadata:
+            labels:
+              app.kubernetes.io/name: troshka-oauth-proxy
+          spec:
+            serviceAccountName: troshka-sa
+            containers:
+              - name: oauth-proxy
+                image: registry.redhat.io/openshift4/ose-oauth-proxy-rhel9:latest
+                ports:
+                  - containerPort: 8443
+                    name: proxy
+                args:
+                  - --provider=openshift
+                  - --https-address=:8443
+                  - --http-address=
+                  - --upstream=http://troshka-frontend.{{ troshka_namespace }}.svc:3000
+                  - --tls-cert=/etc/tls/private/tls.crt
+                  - --tls-key=/etc/tls/private/tls.key
+                  - --cookie-secret-file=/etc/oauth/cookie-secret
+                  - --client-id=system:serviceaccount:{{ troshka_namespace }}:troshka-sa
+                  - --client-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token
+                  - --openshift-service-account=troshka-sa
+                  - --openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                  - --pass-user-headers=true
+                  - --pass-access-token=false
+                  - --skip-auth-regex=^/api/v1/health
+                  - --skip-auth-regex=^/api/v1/auth/config
+                volumeMounts:
+                  - name: tls
+                    mountPath: /etc/tls/private
+                  - name: oauth-secrets
+                    mountPath: /etc/oauth
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+                  limits:
+                    memory: 128Mi
+            volumes:
+              - name: tls
+                secret:
+                  secretName: troshka-oauth-tls  # pragma: allowlist secret
+              - name: oauth-secrets
+                secret:
+                  secretName: troshka-oauth-proxy  # pragma: allowlist secret
+
+- name: Create OAuth proxy Service
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: troshka-oauth-proxy
+        namespace: "{{ troshka_namespace }}"
+        annotations:
+          service.beta.openshift.io/serving-cert-secret-name: troshka-oauth-tls
+      spec:
+        selector:
+          app.kubernetes.io/name: troshka-oauth-proxy
+        ports:
+          - port: 8443
+            targetPort: 8443
+            name: proxy
+
+- name: Create Route
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: route.openshift.io/v1
+      kind: Route
+      metadata:
+        name: troshka
+        namespace: "{{ troshka_namespace }}"
+      spec:
+        host: "{{ _troshka_route_host }}"
+        to:
+          kind: Service
+          name: troshka-oauth-proxy
+        port:
+          targetPort: proxy
+        tls:
+          termination: reencrypt

--- a/ansible/roles/ocp4_workload_troshka_dedicated/tasks/postgres.yaml
+++ b/ansible/roles/ocp4_workload_troshka_dedicated/tasks/postgres.yaml
@@ -1,0 +1,95 @@
+---
+- name: Generate PostgreSQL password
+  ansible.builtin.set_fact:
+    _postgres_password: "{{ lookup('password', '/dev/null chars=ascii_letters,digits length=24') }}"
+
+- name: Create PostgreSQL PVC
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: troshka-postgres-data
+        namespace: "{{ troshka_namespace }}"
+      spec:
+        accessModes: [ReadWriteOnce]
+        resources:
+          requests:
+            storage: "{{ troshka_postgres_pvc_size }}"
+
+- name: Deploy PostgreSQL
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: apps/v1
+      kind: StatefulSet
+      metadata:
+        name: troshka-postgres
+        namespace: "{{ troshka_namespace }}"
+        labels:
+          app.kubernetes.io/name: troshka-postgres
+      spec:
+        replicas: 1
+        serviceName: troshka-postgres
+        selector:
+          matchLabels:
+            app.kubernetes.io/name: troshka-postgres
+        template:
+          metadata:
+            labels:
+              app.kubernetes.io/name: troshka-postgres
+          spec:
+            containers:
+              - name: postgres
+                image: registry.redhat.io/rhel9/postgresql-16:latest
+                env:
+                  - name: POSTGRESQL_USER
+                    value: troshka
+                  - name: POSTGRESQL_PASSWORD
+                    value: "{{ _postgres_password }}"
+                  - name: POSTGRESQL_DATABASE
+                    value: troshka
+                ports:
+                  - containerPort: 5432
+                volumeMounts:
+                  - name: data
+                    mountPath: /var/lib/pgsql/data
+                resources:
+                  requests:
+                    cpu: 250m
+                    memory: 512Mi
+                  limits:
+                    memory: 1Gi
+            volumes:
+              - name: data
+                persistentVolumeClaim:
+                  claimName: troshka-postgres-data
+
+- name: Create PostgreSQL Service
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: troshka-postgres
+        namespace: "{{ troshka_namespace }}"
+      spec:
+        clusterIP: None
+        selector:
+          app.kubernetes.io/name: troshka-postgres
+        ports:
+          - port: 5432
+            targetPort: 5432
+
+- name: Wait for PostgreSQL to be ready
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    kind: StatefulSet
+    name: troshka-postgres
+    namespace: "{{ troshka_namespace }}"
+  register: _pg
+  until: (_pg.resources[0].status.readyReplicas | default(0)) >= 1
+  retries: 30
+  delay: 10

--- a/ansible/roles/ocp4_workload_troshka_dedicated/tasks/remove_workload.yaml
+++ b/ansible/roles/ocp4_workload_troshka_dedicated/tasks/remove_workload.yaml
@@ -1,0 +1,10 @@
+---
+- name: Delete namespace (cascading delete)
+  kubernetes.core.k8s:
+    state: absent
+    definition:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: "{{ troshka_namespace }}"
+  ignore_errors: true

--- a/ansible/roles/ocp4_workload_troshka_dedicated/tasks/s4.yaml
+++ b/ansible/roles/ocp4_workload_troshka_dedicated/tasks/s4.yaml
@@ -1,0 +1,138 @@
+---
+- name: Generate S4 credentials
+  ansible.builtin.set_fact:
+    _s4_access_key: s4admin
+    _s4_secret_key: "{{ lookup('password', '/dev/null chars=ascii_letters,digits length=24') }}"
+
+- name: Create S4 PVC
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: troshka-s4-data
+        namespace: "{{ troshka_namespace }}"
+      spec:
+        accessModes: [ReadWriteOnce]
+        resources:
+          requests:
+            storage: "{{ troshka_s4_pvc_size }}"
+
+- name: Deploy S4
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: troshka-s4
+        namespace: "{{ troshka_namespace }}"
+        labels:
+          app.kubernetes.io/name: troshka-s4
+      spec:
+        replicas: 1
+        selector:
+          matchLabels:
+            app.kubernetes.io/name: troshka-s4
+        template:
+          metadata:
+            labels:
+              app.kubernetes.io/name: troshka-s4
+          spec:
+            containers:
+              - name: s4
+                image: quay.io/rh-aiservices-bu/s4:latest
+                env:
+                  - name: AWS_ACCESS_KEY_ID
+                    value: "{{ _s4_access_key }}"
+                  - name: AWS_SECRET_ACCESS_KEY
+                    value: "{{ _s4_secret_key }}"
+                ports:
+                  - containerPort: 7480
+                    name: s3
+                  - containerPort: 5000
+                    name: ui
+                volumeMounts:
+                  - name: data
+                    mountPath: /var/lib/ceph/radosgw
+                resources:
+                  requests:
+                    cpu: 250m
+                    memory: 512Mi
+                  limits:
+                    memory: 2Gi
+            volumes:
+              - name: data
+                persistentVolumeClaim:
+                  claimName: troshka-s4-data
+
+- name: Create S4 Service
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: troshka-s4
+        namespace: "{{ troshka_namespace }}"
+      spec:
+        selector:
+          app.kubernetes.io/name: troshka-s4
+        ports:
+          - port: 7480
+            targetPort: 7480
+            name: s3
+          - port: 5000
+            targetPort: 5000
+            name: ui
+
+- name: Wait for S4 to be ready
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    kind: Deployment
+    name: troshka-s4
+    namespace: "{{ troshka_namespace }}"
+  register: _s4
+  until: (_s4.resources[0].status.readyReplicas | default(0)) >= 1
+  retries: 30
+  delay: 10
+
+- name: Create bucket via init Job
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: batch/v1
+      kind: Job
+      metadata:
+        name: "s4-init-bucket"
+        namespace: "{{ troshka_namespace }}"
+      spec:
+        ttlSecondsAfterFinished: 300
+        template:
+          spec:
+            restartPolicy: Never
+            containers:
+              - name: awscli
+                image: amazon/aws-cli:latest
+                command:
+                  - /bin/sh
+                  - -c
+                  - |
+                    aws --endpoint-url http://troshka-s4:7480 s3 mb s3://troshka-images || true
+                env:
+                  - name: AWS_ACCESS_KEY_ID
+                    value: "{{ _s4_access_key }}"
+                  - name: AWS_SECRET_ACCESS_KEY
+                    value: "{{ _s4_secret_key }}"
+
+- name: Wait for bucket init job
+  kubernetes.core.k8s_info:
+    api_version: batch/v1
+    kind: Job
+    name: s4-init-bucket
+    namespace: "{{ troshka_namespace }}"
+  register: _init_job
+  until: (_init_job.resources[0].status.succeeded | default(0)) >= 1
+  retries: 12
+  delay: 10

--- a/ansible/roles/ocp4_workload_troshka_dedicated/tasks/secrets.yaml
+++ b/ansible/roles/ocp4_workload_troshka_dedicated/tasks/secrets.yaml
@@ -1,0 +1,27 @@
+---
+- name: Generate JWT secret
+  ansible.builtin.command: python3 -c "import secrets; print(secrets.token_urlsafe(32))"
+  register: _jwt_secret_result
+  changed_when: false
+
+- name: Generate encryption key
+  ansible.builtin.command: python3 -c "import secrets; print(secrets.token_urlsafe(32))"
+  register: _enc_key_result
+  changed_when: false
+
+- name: Create Troshka secrets
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: troshka-secrets
+        namespace: "{{ troshka_namespace }}"
+      type: Opaque
+      stringData:
+        jwt-secret: "{{ _jwt_secret_result.stdout }}"
+        encryption-key: "{{ _enc_key_result.stdout }}"
+        database-url: "postgresql+psycopg2://troshka:{{ _postgres_password }}@troshka-postgres:5432/troshka"
+        s3-access-key: "{{ _s4_access_key }}"
+        s3-secret-key: "{{ _s4_secret_key }}"

--- a/ansible/roles/ocp4_workload_troshka_dedicated/tasks/seed.yaml
+++ b/ansible/roles/ocp4_workload_troshka_dedicated/tasks/seed.yaml
@@ -1,0 +1,94 @@
+---
+- name: Skip seeding if no central S3 configured
+  when: troshka_seed_s3_endpoint | default('') == '' or troshka_seed_images | length == 0
+  ansible.builtin.debug:
+    msg: "No seed images configured, skipping library seeding"
+
+- name: Seed library from central S4
+  when: troshka_seed_s3_endpoint | default('') != '' and troshka_seed_images | length > 0
+  block:
+    - name: Get current user info
+      ansible.builtin.uri:
+        url: "http://troshka-backend.{{ troshka_namespace }}.svc:8200/api/v1/auth/me"
+        headers: "{{ _api_headers }}"
+      register: _user_info
+
+    - name: Run seed job
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: batch/v1
+          kind: Job
+          metadata:
+            name: "troshka-seed-library"
+            namespace: "{{ troshka_namespace }}"
+          spec:
+            ttlSecondsAfterFinished: 600
+            template:
+              spec:
+                restartPolicy: Never
+                containers:
+                  - name: seed
+                    image: amazon/aws-cli:latest
+                    env:
+                      - name: CENTRAL_ACCESS_KEY
+                        value: "{{ troshka_seed_s3_access_key }}"
+                      - name: CENTRAL_SECRET_KEY
+                        value: "{{ troshka_seed_s3_secret_key }}"
+                      - name: LOCAL_ACCESS_KEY
+                        value: "{{ _s4_access_key }}"
+                      - name: LOCAL_SECRET_KEY
+                        value: "{{ _s4_secret_key }}"
+                    command:
+                      - /bin/sh
+                      - -c
+                      - |
+                        {% for img in troshka_seed_images %}
+                        echo "Copying {{ img.s3_object }}..."
+                        AWS_ACCESS_KEY_ID=$CENTRAL_ACCESS_KEY AWS_SECRET_ACCESS_KEY=$CENTRAL_SECRET_KEY \
+                          aws --endpoint-url {{ troshka_seed_s3_endpoint }} s3 cp \
+                          s3://{{ troshka_seed_s3_bucket }}/{{ img.s3_object }} /tmp/{{ img.s3_object }}
+                        AWS_ACCESS_KEY_ID=$LOCAL_ACCESS_KEY AWS_SECRET_ACCESS_KEY=$LOCAL_SECRET_KEY \
+                          aws --endpoint-url http://troshka-s4:7480 s3 cp \
+                          /tmp/{{ img.s3_object }} s3://troshka-images/seed/{{ img.s3_object }}
+                        rm -f /tmp/{{ img.s3_object }}
+                        {% endfor %}
+                        echo "Seed copy complete"
+
+    - name: Wait for seed job to complete
+      kubernetes.core.k8s_info:
+        api_version: batch/v1
+        kind: Job
+        name: troshka-seed-library
+        namespace: "{{ troshka_namespace }}"
+      register: _seed_job
+      until: (_seed_job.resources[0].status.succeeded | default(0)) >= 1
+      retries: 60
+      delay: 15
+
+    - name: Create library items via API
+      ansible.builtin.uri:
+        url: "http://troshka-backend.{{ troshka_namespace }}.svc:8200/api/v1/library/"
+        method: POST
+        headers: "{{ _api_headers }}"
+        body_format: json
+        body:
+          name: "{{ item.name }}"
+          type: "{{ item.type }}"
+          format: "{{ item.format }}"
+        status_code: [200, 201]
+      register: _lib_items
+      loop: "{{ troshka_seed_images }}"
+
+    - name: Move seed files to library paths and finalize
+      ansible.builtin.uri:
+        url: "http://troshka-backend.{{ troshka_namespace }}.svc:8200/api/v1/library/{{ item.json.id }}/finalize-seed"
+        method: POST
+        headers: "{{ _api_headers }}"
+        body_format: json
+        body:
+          seed_key: "seed/{{ troshka_seed_images[idx].s3_object }}"
+          tags: "{{ troshka_seed_images[idx].tags | default([]) }}"
+      loop: "{{ _lib_items.results }}"
+      loop_control:
+        index_var: idx

--- a/ansible/roles/ocp4_workload_troshka_dedicated/tasks/serviceaccount.yaml
+++ b/ansible/roles/ocp4_workload_troshka_dedicated/tasks/serviceaccount.yaml
@@ -1,0 +1,101 @@
+---
+- name: Create namespace
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: "{{ troshka_namespace }}"
+
+- name: Create ServiceAccount
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: troshka-sa
+        namespace: "{{ troshka_namespace }}"
+
+- name: Create Role for Troshka provider
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: troshka-provider
+        namespace: "{{ troshka_namespace }}"
+      rules:
+        - apiGroups: ["kubevirt.io"]
+          resources: ["virtualmachines", "virtualmachineinstances"]
+          verbs: ["get", "list", "create", "delete", "patch", "update"]
+        - apiGroups: ["cdi.kubevirt.io"]
+          resources: ["datavolumes"]
+          verbs: ["get", "list", "create", "delete"]
+        - apiGroups: [""]
+          resources: ["services", "persistentvolumeclaims"]
+          verbs: ["get", "list", "create", "delete", "patch", "update"]
+        - apiGroups: [""]
+          resources: ["persistentvolumes", "nodes"]
+          verbs: ["get", "list"]
+        - apiGroups: [""]
+          resources: ["secrets"]
+          verbs: ["get", "list", "create", "delete"]
+        - apiGroups: ["route.openshift.io"]
+          resources: ["routes"]
+          verbs: ["get", "list", "create", "delete", "patch", "update"]
+        - apiGroups: [""]
+          resources: ["pods"]
+          verbs: ["get", "list"]
+        - apiGroups: [""]
+          resources: ["pods/exec"]
+          verbs: ["create"]
+
+- name: Create RoleBinding
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: troshka-provider
+        namespace: "{{ troshka_namespace }}"
+      subjects:
+        - kind: ServiceAccount
+          name: troshka-sa
+          namespace: "{{ troshka_namespace }}"
+      roleRef:
+        kind: Role
+        name: troshka-provider
+        apiGroup: rbac.authorization.k8s.io
+
+- name: Get SA token for provider registration
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: troshka-sa-token
+        namespace: "{{ troshka_namespace }}"
+        annotations:
+          kubernetes.io/service-account.name: troshka-sa
+      type: kubernetes.io/service-account-token
+  register: _sa_token_secret
+
+- name: Wait for SA token to be populated
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Secret
+    name: troshka-sa-token
+    namespace: "{{ troshka_namespace }}"
+  register: _sa_token_info
+  until: _sa_token_info.resources[0].data.token is defined
+  retries: 10
+  delay: 5
+
+- name: Store SA token
+  ansible.builtin.set_fact:
+    _troshka_sa_token: "{{ _sa_token_info.resources[0].data.token | b64decode }}"


### PR DESCRIPTION
## Summary
- Adds `ocp4_workload_troshka_dedicated` role using S4 (Ceph RGW) instead of MinIO for per-instance object storage
- S4 image: `quay.io/rh-aiservices-bu/s4:latest` (Apache 2.0, replaces AGPL MinIO)
- S3 API on port 7480, web UI on port 5000
- Registers S4 as an S3 provider in Troshka admin UI
- Seed job uses `aws-cli` with read-only creds from central S4 (replaces `mc` from MinIO)
- Central S4 deployed on ocpv-infra01 with gold images already migrated

## Why
MinIO Community Edition was archived (Feb 2026) — no security patches, AGPL licensing risk. S4 uses battle-tested Ceph RADOS Gateway with Apache 2.0 license.

## Test plan
- [ ] Deploy a dedicated Troshka instance with this role
- [ ] Verify S4 pod starts and bucket is created
- [ ] Verify seed job copies gold images from central S4
- [ ] Verify library items appear in Troshka UI
- [ ] Verify S4 shows as a provider in Admin > Providers