### PR TITLE
fix(ee): define INSTALL_PLAYBOOK in outer scope for standalone AAP

### DIFF
--- a/tools/execution_environments/ee-multicloud-public/entrypoint.sh
+++ b/tools/execution_environments/ee-multicloud-public/entrypoint.sh
@@ -224,6 +224,9 @@ WRAPPER
   exec "${ORIGINAL_ARGUMENTS[@]}"
 fi
 
+# Path to the optional dynamic dependency installer (agnosticd-v2 only)
+INSTALL_PLAYBOOK="./ansible/install_dynamic_dependencies.yml"
+
 # Detect AAP execution node environment (-u root pattern)
 AAP=0
 for ((i = 1; i < ${#args[@]}; i++)); do


### PR DESCRIPTION
## Summary

- Define `INSTALL_PLAYBOOK` variable in the outer shell scope before the AAP execution node and ansible-navigator code paths
- Fixes `unbound variable` error introduced by #162 on standalone AAP controllers

## Problem

PR #162 added `[ -f "${INSTALL_PLAYBOOK}" ]` guards at lines 239 and 249, but `INSTALL_PLAYBOOK` is only defined inside the `<<'WRAPPER'` heredoc (line 205), which is a separate script scope. The outer entrypoint runs with `set -eu`, so referencing the undefined variable is fatal:

```
/usr/local/bin/entrypoint: line 239: INSTALL_PLAYBOOK: unbound variable
```

**OCP container groups** are unaffected because they `exec` at line 224 (inside the K8s block) and never reach line 239.

**Standalone AAP controllers** (e.g. `aap2-prod-us-west-2`) hit the AAP execution node path and crash immediately.

Failing job: `aap2-prod-us-west-2` job 300453

## Fix

Add `INSTALL_PLAYBOOK="./ansible/install_dynamic_dependencies.yml"` to the outer scope before the AAP detection block (line 227).

## Test plan

- [ ] Build EE and run an agnosticd v1 job on a standalone AAP controller — should skip dependency install gracefully
- [ ] Run an agnosticd v2 job on a standalone AAP controller — should run dependency install then the playbook
- [ ] Verify OCP container group jobs still work (no change to K8s path)

Ref: GPTEINFRA-17028