### PR TITLE
Change agnosticd -> rhpds for github references

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 
 <!--- Please read first:
 
-https://github.com/agnosticd/agnosticd-v2/blob/main/docs/contributing.adoc
+https://github.com/rhpds/agnosticd-v2/blob/main/docs/contributing.adoc
 
 -->
 

--- a/ansible/collections/ansible_collections/agnosticd/core/galaxy.yml
+++ b/ansible/collections/ansible_collections/agnosticd/core/galaxy.yml
@@ -12,8 +12,8 @@ license:
 - GPL-2.0-or-later
 tags:
 - infrastructure
-repository: https://github.com/agnosticd/agnosticd-v2
-homepage: https://github.com/agnosticd/agnosticd-v2
-issues: https://github.com/agnosticd/agnosticd-v2/issues
+repository: https://github.com/rhpds/agnosticd-v2
+homepage: https://github.com/rhpds/agnosticd-v2
+issues: https://github.com/rhpds/agnosticd-v2/issues
 dependencies: {}
 build_ignore: []

--- a/ansible/configs/cloud-vms-base/default_vars.yml
+++ b/ansible/configs/cloud-vms-base/default_vars.yml
@@ -48,7 +48,7 @@ tower_run: false
 # requirements_content:
 #   collections:
 #   # Cloud VMs Workloads
-#   - name: https://github.com/agnosticd/cloud_vm.git
+#   - name: https://github.com/rhpds/cloud_vm.git
 #     type: git
 #     version: main
 

--- a/ansible/configs/cloud-vms-base/sample-vars/sample-vars-aws.yml
+++ b/ansible/configs/cloud-vms-base/sample-vars/sample-vars-aws.yml
@@ -10,7 +10,7 @@ tag: main
 config: cloud-vms-base
 cloud_provider: aws
 # Only override repo if you need to use your own fork for testing
-# cloud_provider_repo: "https://github.com/agnosticd/cloud_provider_{{ cloud_provider }}.git"
+# cloud_provider_repo: "https://github.com/rhpds/cloud_provider_{{ cloud_provider }}.git"
 cloud_provider_version: "{{ tag }}"
 
 # ===================================================================
@@ -18,11 +18,11 @@ cloud_provider_version: "{{ tag }}"
 # ===================================================================
 requirements_content:
   collections:
-  - name: https://github.com/agnosticd/cloud_vm_workloads.git
+  - name: https://github.com/rhpds/cloud_vm_workloads.git
     type: git
     version: "{{ tag }}"
   # For Showroom
-  - name: https://github.com/agnosticd/core_workloads.git
+  - name: https://github.com/rhpds/core_workloads.git
     type: git
     version: "{{ tag }}"
 

--- a/ansible/configs/namespace/README.adoc
+++ b/ansible/configs/namespace/README.adoc
@@ -58,7 +58,7 @@ E.g.
 requirements_content:
   collections:
   # Core OpenShift Workloads
-  - name: https://github.com/agnosticd/core_workloads.git
+  - name: https://github.com/rhpds/core_workloads.git
     type: git
     version: main
   roles:

--- a/ansible/configs/openshift-cluster/default_vars.yml
+++ b/ansible/configs/openshift-cluster/default_vars.yml
@@ -30,7 +30,7 @@ base_domain: dynamic.redhatworkshops.io
 # requirements_content:
 #   collections:
 #   # Core OpenShift Workloads
-#   - name: https://github.com/agnosticd/core_workloads.git
+#   - name: https://github.com/rhpds/core_workloads.git
 #     type: git
 #     version: main
 

--- a/ansible/configs/openshift-workloads/default_vars.yml
+++ b/ansible/configs/openshift-workloads/default_vars.yml
@@ -5,7 +5,7 @@
 # requirements_content:
 #   collections:
 #   # Core OpenShift Workloads
-#   - name: https://github.com/agnosticd/core_workloads.git
+#   - name: https://github.com/rhpds/core_workloads.git
 #     type: git
 #     version: main
 

--- a/ansible/install_cloud_provider.yml
+++ b/ansible/install_cloud_provider.yml
@@ -11,7 +11,7 @@
     block: |
       # Cloud Provider Collection for {{ cloud_provider }}
       collections:
-      - name: {{ cloud_provider_repo | default('https://github.com/agnosticd/cloud_provider_' ~ cloud_provider ~ '.git') }}
+      - name: {{ cloud_provider_repo | default('https://github.com/rhpds/cloud_provider_' ~ cloud_provider ~ '.git') }}
         type: git
         version: {{ cloud_provider_version | default('main') }}
     marker: "# {mark} ANSIBLE MANAGED BLOCK - cloud provider collection"

--- a/bin/templates/openshift-cluster-aws.yml
+++ b/bin/templates/openshift-cluster-aws.yml
@@ -20,7 +20,7 @@ config: openshift-cluster
 requirements_content:
   collections:
   # Core OpenShift Workloads
-  - name: https://github.com/agnosticd/core_workloads.git
+  - name: https://github.com/rhpds/core_workloads.git
     type: git
     version: "{{ tag }}"
 

--- a/bin/templates/openshift-cluster-cnv.yml
+++ b/bin/templates/openshift-cluster-cnv.yml
@@ -25,7 +25,7 @@ requirements_content:
     version: v0.0.8
 
   # Core OpenShift Workloads
-  - name: https://github.com/agnosticd/core_workloads.git
+  - name: https://github.com/rhpds/core_workloads.git
     type: git
     version: "{{ tag }}"
 

--- a/bin/templates/openshift-workloads.yml
+++ b/bin/templates/openshift-workloads.yml
@@ -19,7 +19,7 @@ config: openshift-workloads
 requirements_content:
   collections:
   # Core OpenShift Workloads
-  - name: https://github.com/agnosticd/core_workloads.git
+  - name: https://github.com/rhpds/core_workloads.git
     type: git
     version: "{{ tag }}"
 

--- a/docs/chained-ee-container-group-fix.md
+++ b/docs/chained-ee-container-group-fix.md
@@ -4,7 +4,7 @@
 
 All `chained-*` EE images fail 100% of jobs on AAP 2.4 container groups (OCP/k8s).
 The same images work fine on bare-metal AAP. The fix is in
-[agnosticd/agnosticd-v2#133](https://github.com/agnosticd/agnosticd-v2/pull/133).
+[agnosticd/agnosticd-v2#133](https://github.com/rhpds/agnosticd-v2/pull/133).
 
 ## Background: How AAP Runs Jobs
 

--- a/docs/contributing.adoc
+++ b/docs/contributing.adoc
@@ -7,7 +7,7 @@ These are our contribution guidelines for helping out with the project. Any sugg
 === General rules
 
 * The Ansible link:https://docs.ansible.com/ansible/latest/community/code_of_conduct.html[Code of Conduct] still applies.
-* For git messages, branch names, etc., follow link:https://github.com/agnosticd/agnosticd-v2/blob/main/docs/git-style-guide.adoc[Git Style Guide].
+* For git messages, branch names, etc., follow link:https://github.com/rhpds/agnosticd-v2/blob/main/docs/git-style-guide.adoc[Git Style Guide].
 * Pull Requests should reference an *issue* whenever possible.
 * Pull Requests must contain a well crafted description.
 ** In your Pull Request, specify `closes #NUM` to automatically close the issue when the PR is merged.
@@ -158,7 +158,7 @@ labels: bug,urgent
 
 === Git
 
-Please follow the link:https://github.com/agnosticd/agnosticd-v2/blob/main/docs/git-style-guide.adoc[Git Style Guide].
+Please follow the link:https://github.com/rhpds/agnosticd-v2/blob/main/docs/git-style-guide.adoc[Git Style Guide].
 
 Note: during the review process, you may add new commits to address review comments or change existing commits. However, before getting your PR merged, please squash commits to a minimum set of meaningful commits. This can be done directly in the github web UI.
 

--- a/docs/conversion_guide.adoc
+++ b/docs/conversion_guide.adoc
@@ -130,7 +130,7 @@ Update the following Babylon `__meta__` settings:
 [source,yaml]
 ----
 deployer:
-  scm_url: https://github.com/agnosticd/agnosticd_v2
+  scm_url: https://github.com/rhpds/agnosticd_v2
   scm_ref: main
 ----
 
@@ -153,7 +153,7 @@ Add the required collections (minimum configuration):
 requirements_content:
   collections:
   # Core OpenShift Workloads
-  - name: https://github.com/agnosticd/core_workloads.git
+  - name: https://github.com/rhpds/core_workloads.git
     type: git
     version: main
 ----

--- a/docs/setup.adoc
+++ b/docs/setup.adoc
@@ -120,7 +120,7 @@ cd ~/Development
 +
 [source,sh]
 ----
-git clone https://github.com/agnosticd/agnosticd-v2
+git clone https://github.com/rhpds/agnosticd-v2
 
 # Or use SSH authentication
 # git clone git@github.com:agnosticd/agnosticd-v2


### PR DESCRIPTION
##### SUMMARY

Change all occurances of github.com/agnosticd/ to github.com/rhpds to account for recent repo moves.
