### PR TITLE
fix: default empty credentials for openshift-workloads destroy

### DIFF
--- a/ansible/configs/openshift-workloads/default_vars.yml
+++ b/ansible/configs/openshift-workloads/default_vars.yml
@@ -19,6 +19,14 @@
 #   openshift_db:
 #     api_url: ...
 #     api_token: ...
+# Credentials typically propagated from a multi-component openshift cluster.
+# Default to empty so that destroy_env.yml does not fail with undefined
+# variable errors when the component provision never completed.
+# The destroyer role tests connectivity and skips unreachable clusters.
+openshift_api_key: ""
+openshift_api_url: ""
+openshift_cluster_admin_token: ""
+
 clusters: {}
 
 # List of workloads to apply to clusters with cluster selector


### PR DESCRIPTION
## Summary

Multi-component catalog items (e.g. RHADS, AAP25 Operator Deployment) use
`propagate_provision_data` to pass cluster credentials (`openshift_api_key`,
`openshift_cluster_admin_token`, `openshift_api_url`) from the openshift
component subject to the parent subject. When the component provision fails,
propagation never runs and these variables remain undefined.

The `destroy_env.yml` playbook then fails with a Jinja2 undefined variable
error when rendering the `clusters` variable — even though the
`openshift_workload_destroyer` role already handles unreachable clusters
gracefully by testing connectivity first and skipping workload removal.

This PR adds empty-string defaults for these three variables in
`default_vars.yml`. When propagation succeeds, the propagated values take
precedence. When it doesn't, the empty defaults let the template render, the
destroyer role finds the cluster unreachable, and the destroy completes
successfully.

Currently 14 destroy-failed AnarchySubjects are stuck due to this issue.

## Test plan

- [ ] Verify destroy succeeds for a catalog item where component provision failed
  (e.g. `pert.redhat-rhads` with undefined `openshift_api_key`)
- [ ] Verify destroy still works normally when credentials are propagated
- [ ] Verify the destroyer role marks empty-credential clusters as unreachable
  and skips workload removal