### PR TITLE
fix: prevent ansible-galaxy from hanging on inaccessible git repos

### DIFF
--- a/ansible/install_cloud_provider.yml
+++ b/ansible/install_cloud_provider.yml
@@ -20,6 +20,16 @@
   ansible.builtin.set_fact:
     _collections_path: "{{ lookup('config', 'COLLECTIONS_PATHS') }}"
 
+- name: Validate cloud provider git URL is reachable
+  ansible.builtin.command:
+    cmd: >-
+      git ls-remote
+      {{ cloud_provider_repo | default('https://github.com/rhpds/cloud_provider_' ~ cloud_provider ~ '.git') }}
+  environment:
+    GIT_TERMINAL_PROMPT: "0"
+  changed_when: false
+  timeout: 30
+
 - name: Install collections from requirements.yml
   vars:
     __collections_path: "{{ lookup('config', 'COLLECTIONS_PATHS')[0] }}"
@@ -28,6 +38,8 @@
     --requirements-file "{{ r_tempfile.path }}"
     --collections-path "{{ __collections_path | quote }}"
     --force-with-deps
+  environment:
+    GIT_TERMINAL_PROMPT: "0"
   register: r_ansible_galaxy_install_collections
   until: r_ansible_galaxy_install_collections is successful
   retries: 3

--- a/ansible/install_collections.yml
+++ b/ansible/install_collections.yml
@@ -22,6 +22,24 @@
       | to_yaml }}
     mode: ug=rw,o=r
 
+- name: Validate git-based collection URLs are reachable
+  ansible.builtin.command:
+    cmd: git ls-remote {{ item.name }}
+  environment:
+    GIT_TERMINAL_PROMPT: "0"
+  loop: >-
+    {{ r_requirements_content.collections
+       | default([])
+       | selectattr('type', 'defined')
+       | selectattr('type', 'equalto', 'git')
+       | list }}
+  loop_control:
+    label: "{{ item.name }}"
+  register: r_git_url_check
+  changed_when: false
+  failed_when: r_git_url_check.rc != 0
+  timeout: 30
+
 - name: Get COLLECTIONS_PATHS
   ansible.builtin.set_fact:
     _collections_path: "{{ lookup('config', 'COLLECTIONS_PATHS') }}"
@@ -36,6 +54,8 @@
     --requirements-file "{{ r_tempfile.path }}"
     --collections-path "{{ _collections_path[0] | quote }}"
     --force-with-deps
+  environment:
+    GIT_TERMINAL_PROMPT: "0"
   register: r_ansible_galaxy_install_collections
   until: r_ansible_galaxy_install_collections is successful
   retries: 3

--- a/ansible/install_dynamic_dependencies.yml
+++ b/ansible/install_dynamic_dependencies.yml
@@ -63,6 +63,8 @@
       {%- else -%}
       {{ playbook_dir | default('.') }}/configs/{{ config }}/roles
       {%- endif -%}"
+    environment:
+      GIT_TERMINAL_PROMPT: "0"
     when: >-
       r_requirements_stat.stat.exists
       and r_requirements_content | default([]) | length > 0


### PR DESCRIPTION
## Problem

When `requirements_content` includes a collection with `type: git` pointing to a nonexistent, private, or renamed GitHub repo, `ansible-galaxy collection install` hangs forever waiting for credentials. EE containers have no TTY, so the credential prompt blocks indefinitely. The `retries: 3` never fire because the command never exits.

Real-world example: Job 312072 hung at "Install collections from requirements.yml" with `Username for 'https://github.com':` because `rhpds/cnv_workloads` had been moved to the `agnosticd` org.

## Fix

**1. `GIT_TERMINAL_PROMPT=0` environment variable** on all `ansible-galaxy` install commands across three files. This tells git to fail immediately (exit 128) instead of prompting for credentials, allowing the retry logic to work correctly.

**2. Pre-flight URL validation** using `git ls-remote` with a 30-second timeout:
- `install_collections.yml`: Validates all `type: git` collection URLs before running `ansible-galaxy`
- `install_cloud_provider.yml`: Validates the cloud provider git URL before install

This gives operators a clear, immediate error message naming the exact URL that's inaccessible, rather than a generic galaxy failure or infinite hang.

## Files changed

- `ansible/install_collections.yml` — pre-flight validation + env var
- `ansible/install_cloud_provider.yml` — pre-flight validation + env var
- `ansible/install_dynamic_dependencies.yml` — env var on roles install

## Testing

```bash
# Nonexistent repo: fails fast with clear error
GIT_TERMINAL_PROMPT=0 git ls-remote https://github.com/rhpds/nonexistent-repo.git
# remote: Repository not found.
# fatal: repository '...' not found
# Exit code: 128

# Valid repo: succeeds normally
GIT_TERMINAL_PROMPT=0 git ls-remote https://github.com/rhpds/cnv_workloads.git
# Exit code: 0
```