### PR TITLE
fix: remove become from localhost workloads play

### DIFF
--- a/ansible/configs/cloud-vms-base/workloads.yml
+++ b/ansible/configs/cloud-vms-base/workloads.yml
@@ -2,7 +2,6 @@
 - name: Install {{ _workload_title_ }}  workloads on localhost
   hosts: localhost
   gather_facts: false
-  become: true
   tasks:
   - name: Deploying {{ _workload_title_ }} workloads  on localhost
     when: _workloads_.localhost | default("") | length > 0


### PR DESCRIPTION
## Summary

Remove play-level `become: true` from the localhost play in `workloads.yml`.

Localhost workloads run inside EE containers where `sudo` is not available. The
play-level `become: true` causes every task in every localhost workload role to
attempt privilege escalation, failing with:

```
/bin/sh: line 1: sudo: command not found
```

This is currently breaking destroy jobs for `demystifying-aap-on-ocp` — the
`rhpds.litellm_virtual_keys` role (which only makes HTTP API calls via
`ansible.builtin.uri`) fails because it inherits `become: true` from the play.

Workloads that genuinely need root access should declare `become: true` on
their own tasks, not rely on play-level inheritance.

## Affected

All localhost workloads under `cloud-vms-base` configs — any role included
via `pre_destroy_workloads.localhost`, `post_software_workloads.localhost`, etc.

## Test plan

- [ ] Verify `demystifying-aap-on-ocp` destroy jobs complete without `sudo` errors
- [ ] Verify existing localhost workloads still function (they should — k8s and uri calls don't need become)