### PR TITLE
Add support for multisno to SSLSandbox/DNSSandbox

### DIFF
--- a/ansible/roles/host_ocp4_assisted_installer/tasks/configure_sno_extra_sno_clusters.yml
+++ b/ansible/roles/host_ocp4_assisted_installer/tasks/configure_sno_extra_sno_clusters.yml
@@ -1,0 +1,142 @@
+---
+- name: Add the service (type LoadBalancer) for control plane
+  vars:
+    svcname: "{{ ai_ocp_vmname_control_plane_prefix }}-svc-{{ _cluster_name }}"
+  kubernetes.core.k8s:
+    definition: "{{ lookup('ansible.builtin.template', 'control_plane_svc.yaml.j2') | from_yaml }}"
+    wait: true
+    wait_timeout: 300
+
+- name: Add the service (type LoadBalancer) for workers
+  vars:
+    svcname: "{{ ai_ocp_vmname_worker_prefix }}-svc-{{ _cluster_name }}"
+    role: "control-plane"
+  kubernetes.core.k8s:
+    definition: "{{ lookup('ansible.builtin.template', 'workers_svc.yaml.j2') | from_yaml }}"
+    wait: true
+    wait_timeout: 300
+
+- name: Wait for the LoadBalancer value - control plane
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Service
+    name: "{{ ai_ocp_vmname_control_plane_prefix }}-svc-{{ _cluster_name }}"
+    namespace: "{{ ai_ocp_namespace }}"
+  register: r_svc_control_plane
+  until: r_svc_control_plane.resources[0].status.loadBalancer.ingress[0].ip | default('') != ''
+  retries: 10
+  delay: 2
+
+- name: Add A DNS record - api (Route53)
+  when: route53_aws_access_key_id is defined
+  amazon.aws.route53:
+    state: present
+    aws_access_key_id: "{{ route53_aws_access_key_id }}"
+    aws_secret_access_key: "{{ route53_aws_secret_access_key }}"
+    hosted_zone_id: "{{ route53_aws_zone_id }}"
+    record: "api.{{ _sno_cluster_name }}.cluster-{{ guid }}.{{ cluster_dns_zone }}"
+    zone: "{{ cluster_dns_zone  }}"
+    value: "{{ r_svc_control_plane.resources[0].status.loadBalancer.ingress[0].ip }}"
+    type: A
+  register: r_route53_add_record
+  until: r_route53_add_record is success
+  retries: 20
+  delay: 30
+
+- name: Add A DNS record - api-int (Route53)
+  when: route53_aws_access_key_id is defined
+  amazon.aws.route53:
+    state: present
+    aws_access_key_id: "{{ route53_aws_access_key_id }}"
+    aws_secret_access_key: "{{ route53_aws_secret_access_key }}"
+    hosted_zone_id: "{{ route53_aws_zone_id }}"
+    record: "api-int.{{ _sno_cluster_name }}.cluster-{{ guid }}.{{ cluster_dns_zone }}"
+    zone: "{{ cluster_dns_zone  }}"
+    value: "{{ ai_network_prefix + '.100' if control_plane_instance_count | int > 1 else ai_network_prefix + '.10' }}"
+    type: A
+  register: r_route53_add_record
+  until: r_route53_add_record is success
+  retries: 20
+  delay: 30
+
+- name: Add A DNS record - apps (Route53)
+  when: route53_aws_access_key_id is defined
+  amazon.aws.route53:
+    state: present
+    aws_access_key_id: "{{ route53_aws_access_key_id }}"
+    aws_secret_access_key: "{{ route53_aws_secret_access_key }}"
+    hosted_zone_id: "{{ route53_aws_zone_id }}"
+    record: "*.apps.{{ _sno_cluster_name }}.cluster-{{ guid }}.{{ cluster_dns_zone }}"
+    zone: "{{ cluster_dns_zone  }}"
+    value: "{{ r_svc_control_plane.resources[0].status.loadBalancer.ingress[0].ip }}"
+    type: A
+  register: r_route53_add_record
+  until: r_route53_add_record is success
+  retries: 20
+  delay: 30
+
+- name: Add A dns record - masters
+  when: cluster_dns_server is defined
+  community.general.nsupdate:
+    server: >-
+      {{ cluster_dns_server
+      | ansible.utils.ipaddr
+      | ternary(cluster_dns_server, lookup('community.general.dig', cluster_dns_server))
+      }}
+    zone: "{{ cluster_dns_zone }}"
+    record: "api.{{ _sno_cluster_name }}.cluster-{{ guid }}"
+    type: A
+    ttl: 30
+    port: "{{ cluster_dns_port | d('53') }}"
+    value: "{{ r_svc_control_plane.resources[0].status.loadBalancer.ingress[0].ip }}"
+    key_name: "{{ ddns_key_name }}"
+    key_secret: "{{ ddns_key_secret }}"
+    key_algorithm: "hmac-sha256"
+  register: r_add_dns_record
+  until: r_add_dns_record is successful
+  retries: 30
+  delay: 5
+
+- name: Add A dns record - masters
+  when: cluster_dns_server is defined
+  community.general.nsupdate:
+    server: >-
+      {{ cluster_dns_server
+      | ansible.utils.ipaddr
+      | ternary(cluster_dns_server, lookup('community.general.dig', cluster_dns_server))
+      }}
+    zone: "{{ cluster_dns_zone }}"
+    record: "api-int.{{ _sno_cluster_name }}.cluster-{{ guid }}"
+    type: A
+    ttl: 30
+    port: "{{ cluster_dns_port | d('53') }}"
+    value: "{{ ai_network_prefix + '.100' if control_plane_instance_count | int > 1 else ai_network_prefix + '.10' }}"
+    key_name: "{{ ddns_key_name }}"
+    key_secret: "{{ ddns_key_secret }}"
+    key_algorithm: "hmac-sha256"
+  register: r_add_dns_record
+  until: r_add_dns_record is successful
+  retries: 30
+  delay: 5
+
+- name: Add A dns record - workers
+  when: cluster_dns_server is defined
+  community.general.nsupdate:
+    server: >-
+      {{ cluster_dns_server
+      | ansible.utils.ipaddr
+      | ternary(cluster_dns_server, lookup('community.general.dig', cluster_dns_server))
+      }}
+    zone: "{{ cluster_dns_zone }}"
+    record: "*.apps.{{ _sno_cluster_name }}.cluster-{{ guid }}"
+    type: A
+    ttl: 30
+    port: "{{ cluster_dns_port | d('53') }}"
+    value: "{{ r_svc_control_plane.resources[0].status.loadBalancer.ingress[0].ip }}"
+    key_name: "{{ ddns_key_name }}"
+    key_secret: "{{ ddns_key_secret }}"
+    key_algorithm: "hmac-sha256"
+  register: r_add_dns_record
+  until: r_add_dns_record is successful
+  retries: 30
+  delay: 5

--- a/ansible/roles/host_ocp4_assisted_installer/tasks/create_sno_extra_sno_clusters.yaml
+++ b/ansible/roles/host_ocp4_assisted_installer/tasks/create_sno_extra_sno_clusters.yaml
@@ -1,8 +1,8 @@
 - name: Create OpenShift cluster using Assisted Installer
   rhpds.assisted_installer.create_cluster:
-    name: "{{ _cluster_name }}"
+    name: "{{ _sno_cluster_name }}"
     openshift_version: "{{ ai_cluster_version }}"
-    base_dns_domain: "{{ cluster_dns_zone }}"
+    base_dns_domain: "cluster-{{ guid }}.{{ cluster_dns_zone }}"
     offline_token: "{{ ai_offline_token }}"
     pull_secret: "{{ ai_pull_secret }}"
     high_availability_mode: "{{ 'Full' if control_plane_instance_count | int > 1 else 'None' }}"

--- a/ansible/roles/host_ocp4_assisted_installer/tasks/main.yaml
+++ b/ansible/roles/host_ocp4_assisted_installer/tasks/main.yaml
@@ -54,12 +54,13 @@
 
   - name: Configure extra SNO clusters
     when: ai_extra_sno_clusters | default([]) | length > 0
-    ansible.builtin.include_tasks: configure_sno_compact_cluster.yml
+    ansible.builtin.include_tasks: configure_sno_extra_sno_clusters.yml
     loop: "{{ ai_extra_sno_clusters }}"
     loop_control:
       loop_var: extra_sno_cluster
     vars:
       _cluster_name: "cluster-{{ guid }}-{{ extra_sno_cluster.name }}"
+      _sno_cluster_name: "{{ extra_sno_cluster.name }}"
       ai_network_prefix: "{{ extra_sno_cluster.ai_network_prefix }}"
 
   - name: Configure a SNO/Compact cluster
@@ -86,6 +87,7 @@
     loop_control:
       loop_var: extra_sno_cluster
     vars:
+      _sno_cluster_name: "{{ extra_sno_cluster.name }}"
       _cluster_name: "cluster-{{ guid }}-{{ extra_sno_cluster.name }}"
       ai_network_prefix: "{{ extra_sno_cluster.ai_network_prefix }}"
       _ai_control_plane_cores: "{{ extra_sno.ai_control_plane_cores | default(ai_control_plane_cores) }}"


### PR DESCRIPTION
##### SUMMARY

Currently running multiple SNO only supports Route53, this PR adds support to DNSSandbox (using ddns/bind)

##### ISSUE TYPE

- Feature Pull Request


##### COMPONENT NAME
role host_ocp4_assisted_installer

