### PR TITLE
Retry assisted-installer host wait on transient API failures

### DIFF
--- a/ansible/roles/host_ocp4_assisted_scale/tasks/main.yaml
+++ b/ansible/roles/host_ocp4_assisted_scale/tasks/main.yaml
@@ -183,6 +183,12 @@
       infra_env_id: "{{ newinfraenv.result.id }}"
       configure_hosts: "{{ ai_configure_hosts }}"
       wait_timeout: 600
+    register: r_wait_for_hosts
+    # the module crashes on a transient empty/non-JSON response from the
+    # assisted-installer API instead of retrying internally
+    until: r_wait_for_hosts is succeeded
+    retries: 3
+    delay: 20
 
 - name: Initialize CSR approval iteration counter
   ansible.builtin.set_fact:


### PR DESCRIPTION
The rhpds.assisted_installer.wait_for_hosts module json-parses the assisted-installer API response and crashes on a transient empty or non-JSON reply ('Expecting value: line 1 column 1 (char 0)') instead of retrying. This killed agd-v2.rhacs-demo-cnv provisions about 90 seconds into the workload on prod1 jobs 37314 (2026-07-14) and 41144 (2026-07-15).

This wraps the task in until/retries (3 x 20s) as a defensive measure. The module's configure_hosts operations are idempotent (hostname/role assignment), so a re-run after a transient API failure is safe. The durable fix is response-tolerant retry inside the collection module itself (rhpds/assisted_installer, would need a v0.0.10 tag plus requirements bumps in the items pinning v0.0.9).

Campaign tracker: [RHDPOPS-23814](https://redhat.atlassian.net/browse/RHDPOPS-23814) (this is flake 2; flake 1 is DNS negative caching, fixed in rhpds/core_workloads#163 plus [GPTEINFRA-17341](https://redhat.atlassian.net/browse/GPTEINFRA-17341) / [GPTEINFRA-17342](https://redhat.atlassian.net/browse/GPTEINFRA-17342)).