### PR TITLE
Add retry logic to assisted-installer wait_for_hosts

### DIFF
--- a/ansible/roles/host_ocp4_assisted_installer/tasks/setup_infrastructure.yml
+++ b/ansible/roles/host_ocp4_assisted_installer/tasks/setup_infrastructure.yml
@@ -158,3 +158,7 @@
     infra_env_id: "{{ newinfraenv.result.id }}"
     configure_hosts: "{{ ai_configure_hosts }}"
     wait_timeout: 600
+  register: r_wait_for_hosts
+  until: r_wait_for_hosts is succeeded
+  retries: 3
+  delay: 20


### PR DESCRIPTION
Transient Assisted Installer API failures can cause `wait_for_hosts` to fail on first attempt. Adding `until/retries/delay` makes it retry up to 3 times with 20s between attempts.

Companion v1 fix: redhat-cop/agnosticd#9872