### PR TITLE
feat: pass user data through deployer to downstream workloads

### DIFF
--- a/ansible/roles/openshift_workload_deployer/tasks/run_workload_on_clusters.yml
+++ b/ansible/roles/openshift_workload_deployer/tasks/run_workload_on_clusters.yml
@@ -17,6 +17,15 @@
     openshift_api_url: "{{ _openshift_workload_deployer_cluster_info[_cluster_name].api_url }}"
     openshift_console_url: "{{ _openshift_workload_deployer_cluster_info[_cluster_name].console_url }}"
     openshift_cluster_ingress_domain: "{{ _openshift_workload_deployer_cluster_info[_cluster_name].ingress_domain }}"
+    # Pass through user data set by authentication workloads so that
+    # downstream workloads (e.g. gitops bootstrap) can consume it
+    # without needing the agnosticd_user_data lookup directly.
+    openshift_cluster_user_password: >-
+      {{ lookup('agnosticd_user_data', 'openshift_cluster_user_password') | default('', true) }}
+    openshift_cluster_user_base: >-
+      {{ lookup('agnosticd_user_data', 'openshift_cluster_user_base') | default('user', true) }}
+    openshift_cluster_num_users: >-
+      {{ lookup('agnosticd_user_data', 'openshift_cluster_num_users') | default(0, true) }}
     # Compute data_prefix in vars where Jinja2 filters resolve correctly.
     # Avoids ansible-core issue with | default() inside apply -> module_defaults.
     _workload_data_prefix: >-


### PR DESCRIPTION
## Summary

- Auth workloads (htpasswd, HCP) store user credentials in `agnosticd_user_info` data, but downstream workloads had no way to access them without knowing about the `agnosticd_user_data` lookup
- Now passes `openshift_cluster_user_password`, `openshift_cluster_user_base`, and `openshift_cluster_num_users` through as vars to all workloads via the deployer
- Defaults gracefully when no auth workload has run (empty password, `user` base, `0` users)

## Context

Field-sourced content (e.g. gitops bootstrap workloads) needs user credentials to wire into helm values. The password was being generated and stored by auth workloads but never forwarded to subsequent workloads.

## Test plan

- [ ] Deploy with auth workload + downstream workload — verify password is available
- [ ] Deploy without auth workload — verify no errors (defaults to empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)