### PR TITLE
Fix AMI re-resolution after capacity reservation region change

### DIFF
--- a/ansible/cloud_providers/aws/infrastructure_deployment.yml
+++ b/ansible/cloud_providers/aws/infrastructure_deployment.yml
@@ -28,7 +28,7 @@
       name: agnosticd.cloud_provider_aws.capacity_reservation
 
   - name: Rerun detection
-    when: agnosticd_aws_capacity_reservation_results.reservations | default({}) | length > 0
+    when: r_agnosticd_aws_capacity_reservation.reservations | default({}) | length > 0
     block:
     - name: Empty the agnosticd_images and run the detection again
       ansible.builtin.set_fact:


### PR DESCRIPTION
## Summary

The "Rerun detection" block in `infrastructure_deployment.yml` that re-resolves AMI images after capacity reservation changes the AWS region **has never worked** due to a variable name mismatch.

### The bug

The `capacity_reservation` role registers its result as `r_agnosticd_aws_capacity_reservation` ([create.yml:L16](https://github.com/rhpds/cloud_provider_aws/blob/main/roles/capacity_reservation/tasks/create.yml#L16)), but the playbook's rerun condition checked `agnosticd_aws_capacity_reservation_results` — a variable that is never set anywhere.

The `| default({}) | length > 0` fallback silently evaluated to `false`, making the entire rerun block dead code.

### Impact

When capacity reservation falls back to a different region than the default, the bastion (and any other instance) AMI — resolved before capacity reservation ran — is from the **wrong region**. AMI IDs are region-specific, so CloudFormation fails:

```
AWS::EC2::Instance bastion1 CREATE_FAILED:
"The image id '[ami-037e488c5d0f0468f]' does not exist"
```

This particularly affects GPU workloads (g6 instances) where capacity is scarce and region fallback is common. Example: [job 57019 on prod0](https://prod0.apps.ocpv-infra01.dal12.infra.demo.redhat.com/#/jobs/playbook/57019/details) — AMI resolved in us-east-2, capacity found in us-east-1, CloudFormation failed.

For SNO deployments (like openshift-ai-v3), having more fallback regions is desirable since there are no multi-AZ EIP quota concerns. This fix unlocks the full `aws-regions-g6.yaml` fallback list for those items.

### The fix

One-line change: `agnosticd_aws_capacity_reservation_results` → `r_agnosticd_aws_capacity_reservation`

```diff
  - name: Rerun detection
-   when: agnosticd_aws_capacity_reservation_results.reservations | default({}) | length > 0
+   when: r_agnosticd_aws_capacity_reservation.reservations | default({}) | length > 0
    block:
```

## Test plan

- [ ] Deploy a catalog item with capacity reservation enabled (e.g. openshift-ai-v3 with `aws_region_from_param: na`)
- [ ] Verify that when capacity reservation selects a different region, the `infra_images` re-run fires and resolves AMIs for the new region
- [ ] Verify that CloudFormation succeeds with the re-resolved AMI
- [ ] Verify no regression when capacity reservation stays in the default region (rerun condition should still fire, images just resolve to the same AMI)