### PR TITLE
lifecycle_hook_post_start.yml - Add conditional for bastions:

### DIFF
--- a/ansible/configs/openshift-cluster/lifecycle_hook_post_start.yml
+++ b/ansible/configs/openshift-cluster/lifecycle_hook_post_start.yml
@@ -68,6 +68,8 @@
   tasks:
   - name: Approve CertificateSigningRequests
     when:
+    - "'bastions' in groups"
+    - groups['bastions'] | length > 0
     - hostvars[groups['bastions'][0]]['r_wait'] is successful
     - host_ocp4_deploy_installation_method != 'rosa'
     ansible.builtin.include_role:


### PR DESCRIPTION
Reference job: https://prod0.apps.ocpv-infra01.dal12.infra.demo.redhat.com/#/jobs/playbook/65998/output

The CSRs approval should only happen if the bastion wait succeeded. If there’s no bastions group, the task should skip, not crash.
