### PR TITLE
feat: add sandbox config for blank cloud sandbox environments

### DIFF
--- a/ansible/configs/sandbox/README.adoc
+++ b/ansible/configs/sandbox/README.adoc
@@ -8,8 +8,9 @@ and other account-level resources within a sandbox-managed cloud account.
 
 == Supported Cloud Providers
 
-* `none` — Cloud credentials come from the sandbox API, not from
-  agnosticd cloud provider provisioning.
+* `aws` — AWS sandbox account. Credentials come from the sandbox API.
+  Infrastructure deployment is a no-op (no VMs or CloudFormation stacks
+  from the cloud provider level).
 
 == Workloads
 
@@ -29,7 +30,7 @@ list is reversed automatically.
 [source,yaml]
 ----
 config: sandbox
-cloud_provider: none
+cloud_provider: aws
 
 workloads:
 - agnosticd.core_workloads.aws_open_environment

--- a/ansible/configs/sandbox/README.adoc
+++ b/ansible/configs/sandbox/README.adoc
@@ -1,0 +1,38 @@
+== Overview
+
+The *sandbox* config provides a minimal lifecycle for blank cloud sandbox
+environments (AWS, etc.) where no VMs or clusters are provisioned.
+
+It runs workload roles on localhost to set up IAM users, credentials, DNS,
+and other account-level resources within a sandbox-managed cloud account.
+
+== Supported Cloud Providers
+
+* `none` — Cloud credentials come from the sandbox API, not from
+  agnosticd cloud provider provisioning.
+
+== Workloads
+
+Workloads are specified as a flat list of fully qualified role names:
+
+[source,yaml]
+----
+workloads:
+- agnosticd.core_workloads.aws_open_environment
+----
+
+On destroy, `remove_workloads` is used if set; otherwise the `workloads`
+list is reversed automatically.
+
+== Example
+
+[source,yaml]
+----
+config: sandbox
+cloud_provider: none
+
+workloads:
+- agnosticd.core_workloads.aws_open_environment
+
+sandbox_enable_ui: true
+----

--- a/ansible/configs/sandbox/aws/infrastructure_deployment.yml
+++ b/ansible/configs/sandbox/aws/infrastructure_deployment.yml
@@ -1,0 +1,12 @@
+---
+- name: Step 001 - Sandbox Infrastructure (no-op)
+  hosts: localhost
+  connection: local
+  become: false
+  gather_facts: false
+  tasks:
+  - name: Sandbox config does not deploy cloud infrastructure
+    ansible.builtin.debug:
+      msg: >-
+        Sandbox config skips infrastructure deployment.
+        AWS credentials are provided by the sandbox API.

--- a/ansible/configs/sandbox/default_vars.yml
+++ b/ansible/configs/sandbox/default_vars.yml
@@ -1,0 +1,33 @@
+---
+# -------------------------------------------------
+# General variables
+# -------------------------------------------------
+purpose: development
+
+output_dir: /tmp/output_dir
+
+guid: notset
+
+project_tag: "{{ config }}-{{ guid }}"
+
+base_domain: dynamic.redhatworkshops.io
+
+# -------------------------------------------------
+# Sandbox config uses no cloud provider infrastructure.
+# AWS credentials come from the sandbox API, not from
+# cloud provider provisioning.
+# -------------------------------------------------
+cloud_provider: none
+
+# -------------------------------------------------
+# Sandbox defaults
+# -------------------------------------------------
+sandbox_enable_ui: true
+sandbox_user_info_messages_enable: true
+sandbox_user_info_data_enable: true
+
+# -------------------------------------------------
+# Workloads
+# -------------------------------------------------
+workloads: []
+remove_workloads: []

--- a/ansible/configs/sandbox/default_vars.yml
+++ b/ansible/configs/sandbox/default_vars.yml
@@ -13,11 +13,10 @@ project_tag: "{{ config }}-{{ guid }}"
 base_domain: dynamic.redhatworkshops.io
 
 # -------------------------------------------------
-# Sandbox config uses no cloud provider infrastructure.
-# AWS credentials come from the sandbox API, not from
-# cloud provider provisioning.
+# Workloads run on localhost. Infrastructure deployment
+# is a no-op — cloud credentials come from the sandbox API.
+# Set cloud_provider in the AgnosticV CI (e.g. aws).
 # -------------------------------------------------
-cloud_provider: none
 
 # -------------------------------------------------
 # Sandbox defaults

--- a/ansible/configs/sandbox/destroy_env.yml
+++ b/ansible/configs/sandbox/destroy_env.yml
@@ -1,0 +1,24 @@
+---
+- name: Destroy sandbox environment
+  hosts: localhost
+  connection: local
+  become: false
+  gather_facts: false
+  tasks:
+  - name: Set destroy workload list
+    ansible.builtin.set_fact:
+      _remove_workloads: >-
+        {{ remove_workloads
+           if (remove_workloads | default([]) | length > 0)
+           else (workloads | default([]) | reverse | list) }}
+
+  - name: Destroy workloads
+    when: _remove_workloads | length > 0
+    ansible.builtin.include_role:
+      name: "{{ _workload }}"
+    vars:
+      ACTION: destroy
+    loop: "{{ _remove_workloads }}"
+    loop_control:
+      loop_var: _workload
+      label: "{{ _workload }}"

--- a/ansible/configs/sandbox/post_infra.yml
+++ b/ansible/configs/sandbox/post_infra.yml
@@ -1,0 +1,10 @@
+---
+- name: Step 002 - Post Infrastructure
+  hosts: localhost
+  connection: local
+  become: false
+  gather_facts: false
+  tasks:
+  - name: Post Infrastructure
+    ansible.builtin.debug:
+      msg: "Step 002 Post Infrastructure"

--- a/ansible/configs/sandbox/post_software.yml
+++ b/ansible/configs/sandbox/post_software.yml
@@ -1,0 +1,10 @@
+---
+- name: Step 005 - Post Software
+  hosts: localhost
+  connection: local
+  become: false
+  gather_facts: false
+  tasks:
+  - name: Post Software
+    ansible.builtin.debug:
+      msg: "Step 005 Post Software"

--- a/ansible/configs/sandbox/pre_infra.yml
+++ b/ansible/configs/sandbox/pre_infra.yml
@@ -1,0 +1,10 @@
+---
+- name: Step 000 - Pre Infrastructure
+  hosts: localhost
+  connection: local
+  become: false
+  gather_facts: false
+  tasks:
+  - name: Pre Infrastructure
+    ansible.builtin.debug:
+      msg: "Step 000 Pre Infrastructure"

--- a/ansible/configs/sandbox/pre_software.yml
+++ b/ansible/configs/sandbox/pre_software.yml
@@ -1,0 +1,10 @@
+---
+- name: Step 003 - Pre Software
+  hosts: localhost
+  connection: local
+  become: false
+  gather_facts: false
+  tasks:
+  - name: Pre Software
+    ansible.builtin.debug:
+      msg: "Step 003 Pre Software"

--- a/ansible/configs/sandbox/software.yml
+++ b/ansible/configs/sandbox/software.yml
@@ -1,0 +1,22 @@
+---
+- name: Step 004 - Software
+  hosts: localhost
+  connection: local
+  become: false
+  gather_facts: false
+  tasks:
+  - name: Validate workloads variable
+    when: workloads is not defined or workloads is not sequence
+    ansible.builtin.fail:
+      msg: "workloads variable is either not defined or is not a list"
+
+  - name: Provision workloads
+    when: workloads | length > 0
+    ansible.builtin.include_role:
+      name: "{{ _workload }}"
+    vars:
+      ACTION: provision
+    loop: "{{ workloads }}"
+    loop_control:
+      loop_var: _workload
+      label: "{{ _workload }}"


### PR DESCRIPTION
## Summary
- New `sandbox` config for blank cloud sandbox environments (AWS, etc.)
- Minimal lifecycle runner — workloads execute on localhost, no VMs or clusters
- Uses `cloud_provider: none`; AWS credentials come from the sandbox API
- Follows the `openshift-workloads` pattern: flat workload list, reversed on destroy

## Related PRs
- **AgnosticV CI**: https://github.com/rhpds/agnosticv/pull/27507
- **core_workloads role**: (creating next)

## Jira
[GPTEINFRA-17461](https://redhat.atlassian.net/browse/GPTEINFRA-17461)