### PR TITLE
fix: pin legacy-rhel EE to ansible-core 2.15.x for Python 2.7 support

### DIFF
--- a/tools/execution_environments/ee-multicloud-legacy-rhel/requirements.txt
+++ b/tools/execution_environments/ee-multicloud-legacy-rhel/requirements.txt
@@ -1,4 +1,4 @@
-ansible-core>=2.16,<2.18
+ansible-core>=2.15,<2.16
 ansible-runner
 ansible-specdoc
 boto3>=1.18.0


### PR DESCRIPTION
## Problem

The `>=2.16,<2.18` pin gave us ansible-core 2.17.14, which still fails on RHEL 7:

- **2.16+**: uses f-strings in `module_utils/basic.py` → `SyntaxError` on Python 2.7
- **2.17+**: adds `from __future__ import annotations` → `SyntaxError` on Python 3.6

https://aap2-prod-us-west-2.aap.infra.demo.redhat.com/#/jobs/playbook/316739/output

## Fix

Pin to `ansible-core>=2.15,<2.16`. 2.15.x is the last version that generates module wrapper code compatible with Python 2.7 on managed nodes.

## After merge

Rebuild and push:
```
gh workflow run manual-build-ee-legacy-rhel --repo rhpds/agnosticd-v2 -f tag=chained-legacy-rhel-2026-07-24
```