### PR TITLE
fix: pin all collections in legacy-rhel EE to Python 2.7/3.6 compat

### DIFF
--- a/tools/execution_environments/ee-multicloud-legacy-rhel/requirements.yml
+++ b/tools/execution_environments/ee-multicloud-legacy-rhel/requirements.yml
@@ -1,22 +1,35 @@
 ---
+# Pinned to match ee-multicloud:chained-2025-09-30 versions.
+# These are the last known-working versions with Python 2.7/3.6
+# on managed nodes (RHEL 7/8).
 collections:
 - name: ansible.netcommon
+  version: ">=8.1,<9"
 - name: ansible.posix
+  version: ">=2.1,<2.2"
 - name: ansible.utils
+  version: ">=6.0,<7"
 - name: ansible.windows
+  version: ">=3.2,<4"
 
 # cryptography
 - name: community.crypto
+  version: ">=3.0,<4"
 - name: community.general
+  version: ">=11.3,<12"
 
 - name: containers.podman
+  version: ">=1.18,<2"
 
 # kubernetes>=12.0.0
 # requests-oauthlib
 # jsonpatch
 - name: kubernetes.core
+  version: ">=6.1,<7"
 - name: kubevirt.core
+  version: ">=2.2,<3"
 - name: community.okd
+  version: ">=5.0,<6"
 
 # -----------------------------------------
 # Red Hat certified collections
@@ -24,23 +37,36 @@ collections:
 - name: ansible.controller
 - name: ansible.eda
 - name: ansible.hub
+  version: ">=1.0,<2"
 - name: ansible.platform
 - name: redhat.rhbk
+  version: ">=3.0,<4"
 - name: redhat.trusted_profile_analyzer
+  version: ">=2.1,<3"
 - name: redhat.insights
+  version: ">=1.3,<2"
 - name: redhat.rhel_system_roles
+  version: ">=1.95,<1.96"
 - name: redhat.artifact_signer
+  version: ">=1.2,<2"
 - name: redhat.satellite
+  version: ">=5.6,<6"
 - name: redhat.openshift
+  version: ">=5.0,<6"
 - name: redhat.openshift_virtualization
+  version: ">=2.2,<3"
 # -----------------------------------------
 
 # Ansible stuff
 - name: awx.awx
+  version: ">=24.6,<25"
 # Needs awx.awx collection
 - name: infra.aap_configuration
+  version: ">=3.7,<4"
 - name: infra.controller_configuration
+  version: ">=3.1,<4"
 - name: infra.eda_configuration
+  version: ">=1.1,<2"
 
 # Cloud Provider Collections
 # boto3 >= 1.18.0
@@ -55,4 +81,6 @@ collections:
 
 # requirements.txt from the collection
 - name: community.vmware
+  version: ">=6.0,<7"
 - name: vmware.vmware_rest
+  version: ">=4.9,<5"


### PR DESCRIPTION
## Problem

ansible-core 2.15 sends module code to managed nodes, but the collection modules themselves also need to be compatible with the managed node's Python. `community.general` 12+ uses `from __future__ import annotations` in `ini_file.py` and other modules, breaking on RHEL 7 (Python 2.7) and RHEL 8 (Python 3.6).

https://prod1.apps.ocpv-infra02.wdc07.infra.demo.redhat.com/#/jobs/playbook/61961/output

## Fix

Pin all collections to the versions from `ee-multicloud:chained-2025-09-30` — the last known-working EE for RHEL 7/8 managed nodes.

Key pins:
- `community.general` >=11.3,<12 (was 13.2.0)
- `ansible.posix` >=2.1,<2.2 (was 2.2.2)
- `redhat.rhel_system_roles` >=1.95,<1.96 (was 1.120.5)

## After merge

```
gh workflow run manual-build-ee-legacy-rhel --repo rhpds/agnosticd-v2 -f tag=chained-legacy-rhel-2026-07-28
```

Then update agnosticv RIPU CI EE tag to `chained-legacy-rhel-2026-07-28`.