### PR TITLE
fix: strip git URL fragment before pre-flight collection reachability check

### DIFF
--- a/ansible/install_collections.yml
+++ b/ansible/install_collections.yml
@@ -24,7 +24,10 @@
 
 - name: Validate git-based collection URLs are reachable
   ansible.builtin.command:
-    cmd: git ls-remote {{ item.name }}
+    # Strip any '#/subdirectory' fragment before checking reachability;
+    # git ls-remote doesn't understand ansible-galaxy's subdirectory
+    # fragment syntax and would otherwise fail on a valid URL.
+    cmd: git ls-remote {{ item.name.split('#')[0] }}
   environment:
     GIT_TERMINAL_PROMPT: "0"
   loop: >-

--- a/ansible/install_collections.yml
+++ b/ansible/install_collections.yml
@@ -27,7 +27,7 @@
     # Strip any '#/subdirectory' fragment before checking reachability;
     # git ls-remote doesn't understand ansible-galaxy's subdirectory
     # fragment syntax and would otherwise fail on a valid URL.
-    cmd: git ls-remote {{ item.name.split('#')[0] }}
+    cmd: "git ls-remote {{ item.name | split('#') | first | quote }}"
   environment:
     GIT_TERMINAL_PROMPT: "0"
   loop: >-


### PR DESCRIPTION
##### SUMMARY

The "Validate git-based collection URLs are reachable" pre-flight check added in #179 runs `git ls-remote` directly on a collection's `name` field. When `name` uses ansible-galaxy's `#/subdirectory` fragment syntax (for installing a collection nested inside a repo, e.g. `https://github.com/org/repo.git#/path/to/collection`), plain `git` doesn't understand that fragment and fails:

```
fatal: unable to update url base from redirection:
  asked for: https://github.com/org/repo.git#/path/to/collection/info/refs?service=git-upload-pack
   redirect: https://github.com/org/repo
```

This aborts `install_collections.yml` before `ansible-galaxy collection install` ever runs, even though `ansible-galaxy` itself fully supports the subdirectory fragment (verified locally: `ansible-galaxy collection install -r requirements.yml` succeeds against a git repo + `#/subdir` fragment once this pre-flight check is bypassed).

Fix strips the `#fragment` before the reachability check, so it validates the same base repo URL that ansible-galaxy will actually clone.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible/install_collections.yml

##### ADDITIONAL INFORMATION

Reproduced locally:

```
$ git ls-remote "https://github.com/rhpds/showroom.git#/my-collection-sub-dir"
fatal: unable to update url base from redirection:
  asked for: https://github.com/rhpds/showroom.git#/my-collection-sub-dir/info/refs?service=git-upload-pack
   redirect: https://github.com/rhpds/showroom

$ git ls-remote "https://github.com/rhpds/showroom.git"
71f62c4...	HEAD
...
```

And confirmed the actual collection install works fine with the fragment intact once the pre-flight check is out of the way:

```
$ ansible-galaxy collection install -r requirements.yml -p ./collections
Installing 'agnosticd.showroom:1.0.0' to '.../collections/ansible_collections/agnosticd/showroom'
agnosticd.showroom:1.0.0 was installed successfully
```

Made with [Cursor](https://cursor.com)